### PR TITLE
버그 픽스

### DIFF
--- a/Assets/BattleRoyaleHeroesPBR/Prefab/Weapon/PBRDefault/HMGDefault.prefab
+++ b/Assets/BattleRoyaleHeroesPBR/Prefab/Weapon/PBRDefault/HMGDefault.prefab
@@ -135,6 +135,7 @@ MonoBehaviour:
   Animator: {fileID: 0}
   eWeaponType: 3
   bulletStartPos: {fileID: 3384555121807068240}
+  muzzle: {fileID: 0}
 --- !u!1001 &2169101389284134659
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -188,7 +189,15 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 198234346748616026, guid: 5d559f54d8e6ab74bbb6f949e8b8b23c, type: 3}
+      propertyPath: playOnAwake
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 198234346748616026, guid: 5d559f54d8e6ab74bbb6f949e8b8b23c, type: 3}
       propertyPath: UVModule.flipV
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 198515452120210940, guid: 5d559f54d8e6ab74bbb6f949e8b8b23c, type: 3}
+      propertyPath: playOnAwake
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 198515452120210940, guid: 5d559f54d8e6ab74bbb6f949e8b8b23c, type: 3}

--- a/Assets/Prefabs/Character/Player.prefab
+++ b/Assets/Prefabs/Character/Player.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &210552076609135349
+--- !u!1 &115406460377357693
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,2887 +8,8 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 289401352103364691}
-  - component: {fileID: 8580103754979948410}
-  m_Layer: 0
-  m_Name: lowerarm_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &289401352103364691
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 210552076609135349}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 998594297420083682}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &8580103754979948410
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 210552076609135349}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e3c430f382484144e925c097c2d33cfe, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 0
-  m_Data:
-    m_ConstrainedObject: {fileID: 2157046098176342394}
-    m_SourceObjects:
-      m_Length: 1
-      m_Item0:
-        transform: {fileID: 8407424675788172468}
-        weight: 1
-      m_Item1:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item2:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item3:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item4:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item5:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item6:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item7:
-        transform: {fileID: 0}
-        weight: 0
-    m_Offset: {x: 0, y: 0, z: 0}
-    m_MinLimit: -180
-    m_MaxLimit: 180
-    m_AimAxis: 1
-    m_UpAxis: 4
-    m_WorldUpType: 0
-    m_WorldUpObject: {fileID: 0}
-    m_WorldUpAxis: 2
-    m_MaintainOffset: 0
-    m_ConstrainedAxes:
-      x: 1
-      y: 1
-      z: 1
---- !u!1 &1805356684446764008
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3699101498662529524}
-  - component: {fileID: 6462978079765270456}
-  - component: {fileID: 6248117271548641805}
-  m_Layer: 7
-  m_Name: Player
-  m_TagString: Player
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3699101498662529524
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1805356684446764008}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2157046097115747058}
-  - {fileID: 6387495218651356608}
-  - {fileID: 6437870964944921167}
-  - {fileID: 4452459474808381925}
-  - {fileID: 3819367472279800127}
-  - {fileID: 6849201056815116209}
-  - {fileID: 4141789439425173366}
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &6462978079765270456
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1805356684446764008}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9ce9b6abc9f37ae4e8741f8034296c8c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  attribute:
-    Health:
-      AttributeName: Health
-      MaxValue: 10
-      BaseValue: 0
-      CurValue: 3.59
-    Attack:
-      AttributeName: Attack
-      MaxValue: 10
-      BaseValue: 0
-      CurValue: 2.04
-    AttackSpeed:
-      AttributeName: AttackSpeed
-      MaxValue: 10
-      BaseValue: 0
-      CurValue: 1.72
-    Speed:
-      AttributeName: Speed
-      MaxValue: 10
-      BaseValue: 0
-      CurValue: 2.58
-  calcVelocity: {x: 0, y: 0, z: 0}
-  characterController: {fileID: 6248117271548641805}
-  jumpHeight: 2
-  gravity: -9.81
-  groundLayerMask:
-    serializedVersion: 2
-    m_Bits: 8
-  groundCheckDistance: 0.3
-  isDead: 0
-  animator: {fileID: 2157046097115747053}
-  controller: {fileID: 4626928265784643191}
-  fxSystem: {fileID: 1272205581764547985}
-  abilitySystem: {fileID: 8928931733619069730}
-  inputController: {fileID: 0}
-  rotationSpeed: 2
-  cameraTransform: {fileID: 0}
-  scanForTargets: {fileID: 7241046244089165072}
-  lookatCam: {fileID: 7011079490586622914}
-  gizmoColor: {r: 1, g: 0, b: 0, a: 1}
-  scanRadius: 5
-  itemLayer:
-    serializedVersion: 2
-    m_Bits: 256
-  itemdescriptionView: {fileID: 0}
-  fireCount: 1
-  fireMultypleCount: 1
-  magnetRange: 3
-  magnetPower: 1.5
---- !u!143 &6248117271548641805
-CharacterController:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1805356684446764008}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Height: 2
-  m_Radius: 0.5
-  m_SlopeLimit: 45
-  m_StepOffset: 0.3
-  m_SkinWidth: 0.0001
-  m_MinMoveDistance: 0.001
-  m_Center: {x: 0, y: 1, z: 0}
---- !u!1 &2157046096363307894
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046096363307895}
-  m_Layer: 0
-  m_Name: foot_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046096363307895
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096363307894}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.1267479, y: -0.07679969, z: -0.13532273, w: 0.9796553}
-  m_LocalPosition: {x: -0.13463134, y: -0.012334914, z: -0.00009856112}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2157046096952503185}
-  m_Father: {fileID: 2157046096909014722}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046096436678066
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046096436678067}
-  m_Layer: 0
-  m_Name: index_03_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046096436678067
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096436678066}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.019108133, y: -0.021374207, z: 0.0004085892, w: 0.99958885}
-  m_LocalPosition: {x: 0.06901601, y: 0.0042007873, z: 0.0040457235}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046098412595019}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046096438143780
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046096438143781}
-  m_Layer: 0
-  m_Name: index_03_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046096438143781
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096438143780}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.019108133, y: -0.021374207, z: 0.0004085892, w: 0.99958885}
-  m_LocalPosition: {x: -0.06901584, y: -0.004201027, z: -0.004045686}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046096874381998}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046096479809263
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046096479809260}
-  m_Layer: 0
-  m_Name: ring_03_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046096479809260
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096479809263}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0.00971795, z: -0, w: 0.9999528}
-  m_LocalPosition: {x: -0.07088354, y: -0.010713612, z: -0.0032234166}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046096746755582}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046096492320270
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046096492320271}
-  - component: {fileID: 2157046096492320268}
-  m_Layer: 0
-  m_Name: Head17
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2157046096492320271
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096492320270}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046096492320268
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096492320270}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300032, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: -0.0046901703, y: 0.04261303, z: 1.3519179}
-    m_Extent: {x: 0.5007817, y: 0.5822783, z: 0.5729898}
-  m_DirtyAABB: 0
---- !u!1 &2157046096514618574
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046096514618575}
-  m_Layer: 0
-  m_Name: spine_01
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046096514618575
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096514618574}
-  serializedVersion: 2
-  m_LocalRotation: {x: -5.1098166e-17, y: -1.6211398e-16, z: -0.05785565, w: 0.998325}
-  m_LocalPosition: {x: -0.14127474, y: 0.0024777667, z: 2.8018493e-17}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2157046096950244109}
-  m_Father: {fileID: 2157046098365232245}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046096545863662
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046096545863663}
-  - component: {fileID: 2157046096545863660}
-  m_Layer: 0
-  m_Name: Body17
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2157046096545863663
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096545863662}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046096545863660
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096545863662}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300072, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: 0.0076747537, y: -0.07708451, z: 0.4484692}
-    m_Extent: {x: 0.52641165, y: 0.63099086, z: 0.5263983}
-  m_DirtyAABB: 0
---- !u!1 &2157046096573855159
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046096573855156}
-  - component: {fileID: 2157046096573855157}
-  m_Layer: 0
-  m_Name: Body18
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2157046096573855156
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096573855159}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046096573855157
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096573855159}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300074, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: 0.03171587, y: -0.097294, z: 0.4642473}
-    m_Extent: {x: 0.60155445, y: 0.61079764, z: 0.53185666}
-  m_DirtyAABB: 0
---- !u!1 &2157046096577505109
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046096577505114}
-  m_Layer: 0
-  m_Name: thigh_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046096577505114
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096577505109}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.08808675, y: -0.015657831, z: 0.9888635, w: 0.11893094}
-  m_LocalPosition: {x: 0.011850503, y: -0.0066443053, z: 0.110424004}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2157046096909014722}
-  m_Father: {fileID: 2157046098365232245}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046096668912961
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046096668912966}
-  - component: {fileID: 2157046096668912967}
-  m_Layer: 0
-  m_Name: Head05
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2157046096668912966
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096668912961}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046096668912967
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096668912961}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300008, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: -0.014683127, y: -0.04074712, z: 1.2441804}
-    m_Extent: {x: 0.5285003, y: 0.5166766, z: 0.5127573}
-  m_DirtyAABB: 0
---- !u!1 &2157046096685411565
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046096685411570}
-  m_Layer: 0
-  m_Name: thumb_01_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046096685411570
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096685411565}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.7996904, y: -0.4921358, z: -0.15047257, w: 0.30928236}
-  m_LocalPosition: {x: -0.060496494, y: 0.026370905, z: -0.05773824}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2157046097046777753}
-  m_Father: {fileID: 2157046098258846160}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046096730851953
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046096730851958}
-  - component: {fileID: 2157046096730851959}
-  m_Layer: 0
-  m_Name: Head02
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2157046096730851958
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096730851953}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046096730851959
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096730851953}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300002, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: 0.024535194, y: 0.19635624, z: 1.2558525}
-    m_Extent: {x: 0.5006984, y: 0.7457301, z: 0.6284697}
-  m_DirtyAABB: 0
---- !u!1 &2157046096746755577
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046096746755582}
-  m_Layer: 0
-  m_Name: ring_02_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046096746755582
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096746755577}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.011837206, y: 0.0082373, z: -0.68030405, w: 0.73278815}
-  m_LocalPosition: {x: -0.080956735, y: -0.015202989, z: 0.00009701045}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2157046096479809260}
-  m_Father: {fileID: 2157046096921138189}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046096846146197
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046096846146202}
-  - component: {fileID: 2157046096846146203}
-  m_Layer: 0
-  m_Name: Body08
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2157046096846146202
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096846146197}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046096846146203
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096846146197}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300054, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: -0.007229924, y: -0.121120885, z: 0.50351}
-    m_Extent: {x: 0.53194827, y: 0.586971, z: 0.56232953}
-  m_DirtyAABB: 0
---- !u!1 &2157046096850853085
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046096850852898}
-  m_Layer: 0
-  m_Name: index_01_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046096850852898
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096850853085}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.05222944, y: -0.0061715096, z: -0.4695172, w: 0.8813555}
-  m_LocalPosition: {x: 0.12400588, y: 0.014340664, z: 0.043471806}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2157046098412595019}
-  m_Father: {fileID: 2157046098051586499}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046096874381993
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046096874381998}
-  m_Layer: 0
-  m_Name: index_02_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046096874381998
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096874381993}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.022786943, y: 0.002945359, z: -0.40929776, w: 0.9121115}
-  m_LocalPosition: {x: -0.08471742, y: -0.011332375, z: -0.0045711263}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2157046096438143781}
-  m_Father: {fileID: 2157046096980991889}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046096893255169
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046096893255174}
-  - component: {fileID: 2157046096893255175}
-  m_Layer: 0
-  m_Name: Body07
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2157046096893255174
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096893255169}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046096893255175
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096893255169}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300052, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: -0.014973938, y: -0.059782505, z: 0.4601206}
-    m_Extent: {x: 0.68371534, y: 0.6384994, z: 0.54447854}
-  m_DirtyAABB: 0
---- !u!1 &2157046096909014781
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046096909014722}
-  m_Layer: 0
-  m_Name: calf_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046096909014722
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096909014781}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.047882114, y: -0.019919308, z: 0.1335271, w: 0.9896874}
-  m_LocalPosition: {x: -0.1545748, y: 0.0043343566, z: 0.0016697466}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2157046096363307895}
-  m_Father: {fileID: 2157046096577505114}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046096918849077
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046096918849082}
-  - component: {fileID: 2157046096918849083}
-  m_Layer: 0
-  m_Name: Head14
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2157046096918849082
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096918849077}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046096918849083
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096918849077}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300026, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: -0.006088078, y: -0.008313596, z: 1.2804426}
-    m_Extent: {x: 0.5317028, y: 0.56758326, z: 0.53972924}
-  m_DirtyAABB: 0
---- !u!1 &2157046096921138188
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046096921138189}
-  m_Layer: 0
-  m_Name: ring_01_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046096921138189
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096921138188}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.052653857, y: 0.0042588566, z: -0.80677736, w: 0.5884894}
-  m_LocalPosition: {x: -0.12707222, y: -0.012645725, z: 0.04131098}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2157046096746755582}
-  m_Father: {fileID: 2157046098258846160}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046096936087664
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046096936087665}
-  - component: {fileID: 2157046096936087670}
-  m_Layer: 0
-  m_Name: Body02
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2157046096936087665
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096936087664}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046096936087670
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096936087664}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300042, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: 0.029420018, y: -0.04755336, z: 0.4913504}
-    m_Extent: {x: 0.541489, y: 0.66053826, z: 0.55294776}
-  m_DirtyAABB: 0
---- !u!1 &2157046096950244108
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046096950244109}
-  m_Layer: 0
-  m_Name: spine_02
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046096950244109
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096950244108}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.13051149, y: 0.0019590356, z: -0.11750843, w: 0.98445654}
-  m_LocalPosition: {x: -0.14993994, y: 0.02061772, z: 4.3672006e-17}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2157046098175326834}
-  m_Father: {fileID: 2157046096514618575}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046096952503184
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046096952503185}
-  m_Layer: 0
-  m_Name: ball_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046096952503185
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096952503184}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.0030611525, y: -0.008212709, z: 0.7100026, w: 0.70414454}
-  m_LocalPosition: {x: -0.020676007, y: 0.17323625, z: -0.0007544282}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046096363307895}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046096978929486
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046096978929487}
-  m_Layer: 0
-  m_Name: thumb_03_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046096978929487
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096978929486}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.023968818, y: -0.023600308, z: -0.025017621, w: 0.99912095}
-  m_LocalPosition: {x: -0.06190364, y: -0.0001583865, z: 0.00014239138}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097046777753}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046096980991888
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046096980991889}
-  m_Layer: 0
-  m_Name: index_01_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046096980991889
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096980991888}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.051915236, y: -0.008414891, z: -0.43112874, w: 0.90075636}
-  m_LocalPosition: {x: -0.12400577, y: -0.014340727, z: -0.043471765}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2157046096874381998}
-  m_Father: {fileID: 2157046098258846160}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046096982130253
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046096982130258}
-  - component: {fileID: 2157046096982130259}
-  m_Layer: 0
-  m_Name: Head04
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2157046096982130258
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096982130253}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 1.4519753, z: -1.2884914}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046096982130259
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046096982130253}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300006, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: -0.008140445, y: -0.08308093, z: 1.3461982}
-    m_Extent: {x: 0.57529426, y: 0.55149704, z: 0.53545773}
-  m_DirtyAABB: 0
---- !u!1 &2157046097008342435
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046097008342432}
-  - component: {fileID: 2157046097008342433}
-  m_Layer: 0
-  m_Name: Head15
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2157046097008342432
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097008342435}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 1.429432, z: -1.3900039}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046097008342433
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097008342435}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300028, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: -0.006421268, y: -0.020459592, z: 1.3793222}
-    m_Extent: {x: 0.41744748, y: 0.5455019, z: 0.60665214}
-  m_DirtyAABB: 0
---- !u!1 &2157046097013968985
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046097013968990}
-  - component: {fileID: 2157046097013968991}
-  m_Layer: 0
-  m_Name: Body10
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2157046097013968990
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097013968985}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046097013968991
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097013968985}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300058, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: 0.004420042, y: -0.09150994, z: 0.44983375}
-    m_Extent: {x: 0.5335111, y: 0.59556806, z: 0.52824426}
-  m_DirtyAABB: 0
---- !u!1 &2157046097046777752
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046097046777753}
-  m_Layer: 0
-  m_Name: thumb_02_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046097046777753
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097046777752}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.24762599, y: -0.34194008, z: -0.61408085, w: 0.66683066}
-  m_LocalPosition: {x: -0.075063676, y: 0.0011263808, z: 0.00038358383}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2157046096978929487}
-  m_Father: {fileID: 2157046096685411570}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046097053317108
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046097053317109}
-  - component: {fileID: 2157046097053317114}
-  m_Layer: 0
-  m_Name: Body15
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2157046097053317109
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097053317108}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046097053317114
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097053317108}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300068, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: 0.028638601, y: -0.04786834, z: 0.5093344}
-    m_Extent: {x: 0.7141261, y: 0.67605674, z: 0.5937416}
-  m_DirtyAABB: 0
---- !u!1 &2157046097101375773
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046097101375842}
-  m_Layer: 0
-  m_Name: thumb_03_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046097101375842
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097101375773}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.023968818, y: -0.023600308, z: -0.025017621, w: 0.99912095}
-  m_LocalPosition: {x: 0.061903976, y: 0.00015877343, z: -0.00014186987}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046098458972418}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046097102626823
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046097102626820}
-  m_Layer: 0
-  m_Name: clavicle_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046097102626820
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097102626823}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.017211089, y: -0.7295103, z: 0.10917408, w: 0.6749811}
-  m_LocalPosition: {x: -0.0040904805, y: 0.007489476, z: -0.09530931}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2157046098029532669}
-  m_Father: {fileID: 2157046098175326834}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046097115747052
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046097115747058}
-  - component: {fileID: 2157046097115747053}
-  - component: {fileID: 4626928265784643191}
-  - component: {fileID: 3226077727085036935}
-  - component: {fileID: 4143566850067144206}
-  m_Layer: 0
-  m_Name: PlayerModel
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046097115747058
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097115747052}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2157046097787731978}
-  - {fileID: 2157046096936087665}
-  - {fileID: 2157046097874492650}
-  - {fileID: 2157046098446638458}
-  - {fileID: 2157046098118469732}
-  - {fileID: 2157046097776198276}
-  - {fileID: 2157046096893255174}
-  - {fileID: 2157046096846146202}
-  - {fileID: 2157046097373836511}
-  - {fileID: 2157046097013968990}
-  - {fileID: 2157046098345701011}
-  - {fileID: 2157046098004903901}
-  - {fileID: 2157046097978488006}
-  - {fileID: 2157046097117473131}
-  - {fileID: 2157046097053317109}
-  - {fileID: 2157046097497147733}
-  - {fileID: 2157046096545863663}
-  - {fileID: 2157046096573855156}
-  - {fileID: 2157046097169981889}
-  - {fileID: 2157046097487697437}
-  - {fileID: 2157046097409842623}
-  - {fileID: 2157046096730851958}
-  - {fileID: 2157046097840557926}
-  - {fileID: 2157046096982130258}
-  - {fileID: 2157046096668912966}
-  - {fileID: 2157046098191101141}
-  - {fileID: 2157046098362991003}
-  - {fileID: 2157046097468210860}
-  - {fileID: 2157046098323454975}
-  - {fileID: 2157046097674013365}
-  - {fileID: 2157046097568394035}
-  - {fileID: 2157046097650309575}
-  - {fileID: 2157046098372877626}
-  - {fileID: 2157046096918849082}
-  - {fileID: 2157046097008342432}
-  - {fileID: 2157046098390396143}
-  - {fileID: 2157046096492320271}
-  - {fileID: 2157046097281985954}
-  - {fileID: 2157046097142639304}
-  - {fileID: 2157046098261556418}
-  - {fileID: 2157046097784970231}
-  - {fileID: 998594297420083682}
-  m_Father: {fileID: 3699101498662529524}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!95 &2157046097115747053
-Animator:
-  serializedVersion: 7
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097115747052}
-  m_Enabled: 1
-  m_Avatar: {fileID: 9000000, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Controller: {fileID: 9100000, guid: ddd667bde1791624b934575b2f8b545c, type: 2}
-  m_CullingMode: 1
-  m_UpdateMode: 0
-  m_ApplyRootMotion: 0
-  m_LinearVelocityBlending: 0
-  m_StabilizeFeet: 0
-  m_AnimatePhysics: 0
-  m_WarningMessage: 
-  m_HasTransformHierarchy: 1
-  m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorStateOnDisable: 0
-  m_WriteDefaultValuesOnDisable: 0
---- !u!114 &4626928265784643191
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097115747052}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 93005e4cac64995478b011a4506c7e69, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_heads:
-  - {fileID: 2157046097409842622}
-  - {fileID: 2157046096730851953}
-  - {fileID: 2157046097840557921}
-  - {fileID: 2157046096982130253}
-  - {fileID: 2157046096668912961}
-  - {fileID: 2157046098191101140}
-  - {fileID: 2157046098362991002}
-  - {fileID: 2157046097468210863}
-  - {fileID: 2157046098323454974}
-  - {fileID: 2157046097674013364}
-  - {fileID: 2157046097568394034}
-  - {fileID: 2157046097650309574}
-  - {fileID: 2157046098372877621}
-  - {fileID: 2157046096918849077}
-  - {fileID: 2157046097008342435}
-  - {fileID: 2157046098390396142}
-  - {fileID: 2157046096492320270}
-  - {fileID: 2157046097281983069}
-  - {fileID: 2157046097142639307}
-  - {fileID: 2157046098261556477}
-  m_bodys:
-  - {fileID: 2157046097787731973}
-  - {fileID: 2157046096936087664}
-  - {fileID: 2157046097874492645}
-  - {fileID: 2157046098446638453}
-  - {fileID: 2157046098118469735}
-  - {fileID: 2157046097776198279}
-  - {fileID: 2157046096893255169}
-  - {fileID: 2157046096846146197}
-  - {fileID: 2157046097373836510}
-  - {fileID: 2157046097013968985}
-  - {fileID: 2157046098345701010}
-  - {fileID: 2157046098004903900}
-  - {fileID: 2157046097978488001}
-  - {fileID: 2157046097117473130}
-  - {fileID: 2157046097053317108}
-  - {fileID: 2157046097497147732}
-  - {fileID: 2157046096545863662}
-  - {fileID: 2157046096573855159}
-  - {fileID: 2157046097169981888}
-  - {fileID: 2157046097487697436}
-  m_weapons:
-  - {fileID: 2681370085982890864}
-  - {fileID: 1379439075492843939}
-  - {fileID: 1020899677359043502}
-  character: {fileID: 6462978079765270456}
---- !u!114 &3226077727085036935
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097115747052}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fff0960ef4ea6e04eac66b4a7fd2189d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_RigLayers:
-  - m_Rig: {fileID: 3806700233998148600}
-    m_Active: 1
-  m_Effectors: []
---- !u!114 &4143566850067144206
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097115747052}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b2d8418b0b9634b1892b0268dd9c2743, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  boneShape: 1
-  drawBones: 1
-  drawTripods: 0
-  boneSize: 1
-  tripodSize: 1
-  boneColor: {r: 0, g: 0, b: 1, a: 0.5}
-  m_Transforms:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096685411570}
-  - {fileID: 8352545393611895946}
-  - {fileID: 845869089450639126}
-  - {fileID: 470268200330092199}
-  - {fileID: 8568958832614626854}
-  - {fileID: 6381257622104516069}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046098238889439}
-  - {fileID: 1509944659781667751}
-  - {fileID: 5447931079856381715}
-  - {fileID: 7309651607474143062}
-  - {fileID: 1416820251381758304}
-  - {fileID: 6230609969808532733}
-  - {fileID: 4859116730437903325}
-  - {fileID: 6851432739259148266}
-  - {fileID: 1295365205838893994}
-  - {fileID: 2914284825439349230}
-  - {fileID: 9096785062607884852}
-  - {fileID: 6082940367156102425}
-  - {fileID: 4799138432823119025}
-  - {fileID: 748935095315254582}
-  - {fileID: 643212804847895770}
-  - {fileID: 2592056586893115982}
-  - {fileID: 8314838422372595480}
-  - {fileID: 3481062188485462049}
-  - {fileID: 1375819734126365222}
-  - {fileID: 6917227880644008069}
-  - {fileID: 3965906240577453091}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
---- !u!1 &2157046097117473130
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046097117473131}
-  - component: {fileID: 2157046097117473128}
-  m_Layer: 0
-  m_Name: Body14
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2157046097117473131
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097117473130}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046097117473128
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097117473130}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300066, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: 0.0059496164, y: -0.07991725, z: 0.45345753}
-    m_Extent: {x: 0.52711755, y: 0.59585094, z: 0.5294749}
-  m_DirtyAABB: 0
---- !u!1 &2157046097142639307
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046097142639304}
-  - component: {fileID: 2157046097142639305}
+  - component: {fileID: 3321515076464057684}
+  - component: {fileID: 8753184935619906869}
   m_Layer: 0
   m_Name: Head19
   m_TagString: Untagged
@@ -2896,28 +17,28 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 0
---- !u!4 &2157046097142639304
+--- !u!4 &3321515076464057684
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097142639307}
+  m_GameObject: {fileID: 115406460377357693}
   serializedVersion: 2
   m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 2157046097115747058}
+  m_Father: {fileID: 3874544495950623930}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046097142639305
+--- !u!137 &8753184935619906869
 SkinnedMeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097142639307}
+  m_GameObject: {fileID: 115406460377357693}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -2961,54 +82,54 @@ SkinnedMeshRenderer:
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: 4300036, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
   m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
+  m_RootBone: {fileID: 8492314803017277401}
   m_AABB:
     m_Center: {x: 0.007824272, y: -0.10160056, z: 1.2822778}
     m_Extent: {x: 0.41081327, y: 0.47332874, z: 0.5096079}
   m_DirtyAABB: 0
---- !u!1 &2157046097169981888
+--- !u!1 &136387463916557188
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3016,289 +137,86 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2157046097169981889}
-  - component: {fileID: 2157046097169981894}
+  - component: {fileID: 720609310541482530}
+  - component: {fileID: 4446815872253197176}
   m_Layer: 0
-  m_Name: Body19
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2157046097169981889
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097169981888}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046097169981894
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097169981888}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300076, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: 0.016650587, y: -0.42388144, z: 0.58969605}
-    m_Extent: {x: 0.51655173, y: 0.8531207, z: 0.6580695}
-  m_DirtyAABB: 0
---- !u!1 &2157046097186492377
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046097186492382}
-  m_Layer: 0
-  m_Name: ring_01_r
+  m_Name: Hand_rAnim
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &2157046097186492382
+--- !u!4 &720609310541482530
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097186492377}
+  m_GameObject: {fileID: 136387463916557188}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.05282559, y: 0.00015425438, z: -0.8500691, w: 0.52401525}
-  m_LocalPosition: {x: 0.12707186, y: 0.012645532, z: -0.041310944}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.329, y: 5.27, z: 4.8}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 2157046097289563942}
-  m_Father: {fileID: 2157046098051586499}
+  - {fileID: 8237531065322750037}
+  m_Father: {fileID: 8518602567768092522}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046097281983069
-GameObject:
+--- !u!114 &4446815872253197176
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046097281985954}
-  - component: {fileID: 2157046097281985955}
-  m_Layer: 0
-  m_Name: Head18
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2157046097281985954
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097281983069}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 1.6317652, z: -1.4065672}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046097281985955
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097281983069}
+  m_GameObject: {fileID: 136387463916557188}
   m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300034, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: -0.008751035, y: -0.10532588, z: 1.4909414}
-    m_Extent: {x: 0.7895002, y: 0.69968027, z: 0.7182714}
-  m_DirtyAABB: 0
---- !u!1 &2157046097289563937
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3c430f382484144e925c097c2d33cfe, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 0
+  m_Data:
+    m_ConstrainedObject: {fileID: 5914098565606461513}
+    m_SourceObjects:
+      m_Length: 1
+      m_Item0:
+        transform: {fileID: 9211380619938324221}
+        weight: 1
+      m_Item1:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item2:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item3:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item4:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item5:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item6:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item7:
+        transform: {fileID: 0}
+        weight: 0
+    m_Offset: {x: 0, y: 0, z: 0}
+    m_MinLimit: -31
+    m_MaxLimit: -4
+    m_AimAxis: 0
+    m_UpAxis: 4
+    m_WorldUpType: 0
+    m_WorldUpObject: {fileID: 0}
+    m_WorldUpAxis: 2
+    m_MaintainOffset: 0
+    m_ConstrainedAxes:
+      x: 1
+      y: 1
+      z: 1
+--- !u!1 &209017493389202803
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3306,160 +224,54 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2157046097289563942}
+  - component: {fileID: 7524939866931432794}
+  - component: {fileID: 1940242716080151451}
   m_Layer: 0
-  m_Name: ring_02_r
+  m_Name: Rig 4
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &2157046097289563942
+--- !u!4 &7524939866931432794
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097289563937}
+  m_GameObject: {fileID: 209017493389202803}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.011487454, y: 0.008718428, z: -0.6495072, w: 0.76021874}
-  m_LocalPosition: {x: 0.08095703, y: 0.015202765, z: -0.000097014985}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -5.27, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 2157046097523559931}
-  m_Father: {fileID: 2157046097186492382}
+  - {fileID: 5299052495832415554}
+  m_Father: {fileID: 3874544495950623930}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046097373836510
-GameObject:
+--- !u!114 &1940242716080151451
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046097373836511}
-  - component: {fileID: 2157046097373836508}
-  m_Layer: 0
-  m_Name: Body09
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2157046097373836511
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097373836510}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046097373836508
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097373836510}
+  m_GameObject: {fileID: 209017493389202803}
   m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300056, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: -0.01132071, y: -0.10165703, z: 0.47638214}
-    m_Extent: {x: 0.69745475, y: 0.60627747, z: 0.543936}
-  m_DirtyAABB: 0
---- !u!1 &2157046097409842622
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 70b342d8ce5c2fd48b8fa3147d48d1d1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 1
+  m_Effectors:
+  - m_Transform: {fileID: 101793195980115989}
+    m_Style:
+      shape: {fileID: 4300000, guid: e050c2b16fe384bd994474655a4b4968, type: 2}
+      color: {r: 1, g: 0, b: 0, a: 0.5}
+      size: 1.27
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+--- !u!1 &308324437845187188
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3467,160 +279,31 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2157046097409842623}
-  - component: {fileID: 2157046097409842620}
+  - component: {fileID: 4523454433111889778}
   m_Layer: 0
-  m_Name: Head01
+  m_Name: clavicle_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &2157046097409842623
+--- !u!4 &4523454433111889778
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097409842622}
+  m_GameObject: {fileID: 308324437845187188}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046097409842620
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097409842622}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300000, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: -0.011383608, y: 0.030555248, z: 1.409427}
-    m_Extent: {x: 0.49479586, y: 0.5884634, z: 0.636757}
-  m_DirtyAABB: 0
---- !u!1 &2157046097415955044
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046097415955045}
-  m_Layer: 0
-  m_Name: foot_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046097415955045
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097415955044}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.11773011, y: -0.07301172, z: 0.036255144, w: 0.9896941}
-  m_LocalPosition: {x: 0.13463174, y: 0.0123348655, z: 0.00009769745}
+  m_LocalRotation: {x: 0.017211089, y: -0.7295103, z: 0.10917408, w: 0.6749811}
+  m_LocalPosition: {x: -0.0040904805, y: 0.007489476, z: -0.09530931}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 2157046098139437972}
-  m_Father: {fileID: 2157046097997731440}
+  - {fileID: 8887427830417507289}
+  m_Father: {fileID: 8598222625752667699}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046097434715595
+--- !u!1 &311006057720701336
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3628,618 +311,8 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2157046097434715592}
-  m_Layer: 0
-  m_Name: head
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046097434715592
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097434715595}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.18628515, y: -0.017911617, z: -0.09401923, w: 0.9778228}
-  m_LocalPosition: {x: -0.27939242, y: 0.038948957, z: -0.0059307474}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046098153319694}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046097468210863
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046097468210860}
-  - component: {fileID: 2157046097468210861}
-  m_Layer: 0
-  m_Name: Head08
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2157046097468210860
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097468210863}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046097468210861
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097468210863}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300014, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: -0.0062411427, y: -0.013890296, z: 1.2690101}
-    m_Extent: {x: 0.41955596, y: 0.4166621, z: 0.49634004}
-  m_DirtyAABB: 0
---- !u!1 &2157046097487697436
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046097487697437}
-  - component: {fileID: 2157046097487697506}
-  m_Layer: 0
-  m_Name: Body20
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2157046097487697437
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097487697436}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046097487697506
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097487697436}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300078, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: 0.0074983686, y: -0.12014857, z: 0.4533637}
-    m_Extent: {x: 0.5060537, y: 0.5879432, z: 0.5344309}
-  m_DirtyAABB: 0
---- !u!1 &2157046097497147732
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046097497147733}
-  - component: {fileID: 2157046097497147738}
-  m_Layer: 0
-  m_Name: Body16
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2157046097497147733
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097497147732}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046097497147738
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097497147732}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300070, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: 0.0043288767, y: -0.117221326, z: 0.5234725}
-    m_Extent: {x: 0.5103134, y: 0.590711, z: 0.6049771}
-  m_DirtyAABB: 0
---- !u!1 &2157046097523559930
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046097523559931}
-  m_Layer: 0
-  m_Name: ring_03_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046097523559931
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097523559930}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: -0.00971795, z: -0, w: 0.9999528}
-  m_LocalPosition: {x: 0.070884004, y: 0.010713819, z: 0.0032234276}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097289563942}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046097568394034
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046097568394035}
-  - component: {fileID: 2157046097568394032}
-  m_Layer: 0
-  m_Name: Head11
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2157046097568394035
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097568394034}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046097568394032
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097568394034}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300020, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: -0.021726727, y: -0.07339668, z: 1.3876714}
-    m_Extent: {x: 0.607611, y: 0.61443245, z: 0.6150013}
-  m_DirtyAABB: 0
---- !u!1 &2157046097615537288
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046097615537289}
-  m_Layer: 0
-  m_Name: thigh_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046097615537289
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097615537288}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.025237134, y: 0.08581908, z: -0.2812596, w: 0.9554534}
-  m_LocalPosition: {x: 0.011850943, y: -0.0066443863, z: -0.11042425}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2157046097997731440}
-  m_Father: {fileID: 2157046098365232245}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046097650309574
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046097650309575}
-  - component: {fileID: 2157046097650309572}
+  - component: {fileID: 4000473531145385761}
+  - component: {fileID: 3370094258076888510}
   m_Layer: 0
   m_Name: Head12
   m_TagString: Untagged
@@ -4247,28 +320,28 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 0
---- !u!4 &2157046097650309575
+--- !u!4 &4000473531145385761
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097650309574}
+  m_GameObject: {fileID: 311006057720701336}
   serializedVersion: 2
   m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 2157046097115747058}
+  m_Father: {fileID: 3874544495950623930}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046097650309572
+--- !u!137 &3370094258076888510
 SkinnedMeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097650309574}
+  m_GameObject: {fileID: 311006057720701336}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -4312,54 +385,54 @@ SkinnedMeshRenderer:
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: 4300022, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
   m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
+  m_RootBone: {fileID: 8492314803017277401}
   m_AABB:
     m_Center: {x: -0.008002162, y: -0.07804841, z: 1.3369212}
     m_Extent: {x: 0.5322287, y: 0.55781746, z: 0.5642512}
   m_DirtyAABB: 0
---- !u!1 &2157046097674013364
+--- !u!1 &680322541069872126
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4367,1284 +440,7 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2157046097674013365}
-  - component: {fileID: 2157046097674013370}
-  m_Layer: 0
-  m_Name: Head10
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2157046097674013365
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097674013364}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046097674013370
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097674013364}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300018, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: -0.014941692, y: -0.051621675, z: 1.3762658}
-    m_Extent: {x: 0.68065834, y: 0.6584497, z: 0.60359573}
-  m_DirtyAABB: 0
---- !u!1 &2157046097776198279
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046097776198276}
-  - component: {fileID: 2157046097776198277}
-  m_Layer: 0
-  m_Name: Body06
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2157046097776198276
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097776198279}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046097776198277
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097776198279}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300050, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: -0.018616438, y: 0.04596275, z: 0.48210913}
-    m_Extent: {x: 0.6623423, y: 0.7539962, z: 0.5807361}
-  m_DirtyAABB: 0
---- !u!1 &2157046097784970230
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046097784970231}
-  m_Layer: 0
-  m_Name: root
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046097784970231
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097784970230}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2157046098365232245}
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046097787731973
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046097787731978}
-  - component: {fileID: 2157046097787731979}
-  m_Layer: 0
-  m_Name: Body01
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046097787731978
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097787731973}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046097787731979
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097787731973}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300040, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: -0.010785818, y: -0.09531519, z: 0.48286515}
-    m_Extent: {x: 0.6487969, y: 0.59313667, z: 0.56032485}
-  m_DirtyAABB: 0
---- !u!1 &2157046097840557921
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046097840557926}
-  - component: {fileID: 2157046097840557927}
-  m_Layer: 0
-  m_Name: Head03
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2157046097840557926
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097840557921}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046097840557927
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097840557921}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300004, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: -0.0072407424, y: -0.05030465, z: 1.3460083}
-    m_Extent: {x: 0.46757722, y: 0.43353295, z: 0.57333827}
-  m_DirtyAABB: 0
---- !u!1 &2157046097874492645
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046097874492650}
-  - component: {fileID: 2157046097874492651}
-  m_Layer: 0
-  m_Name: Body03
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2157046097874492650
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097874492645}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046097874492651
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097874492645}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300044, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: -0.004300624, y: -0.08930412, z: 0.48370504}
-    m_Extent: {x: 0.51579297, y: 0.6187875, z: 0.5644741}
-  m_DirtyAABB: 0
---- !u!1 &2157046097978488001
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046097978488006}
-  - component: {fileID: 2157046097978488007}
-  m_Layer: 0
-  m_Name: Body13
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2157046097978488006
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097978488001}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046097978488007
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097978488001}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300064, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: -0.0009431541, y: -0.08320141, z: 0.4614281}
-    m_Extent: {x: 0.54177165, y: 0.60521185, z: 0.52980155}
-  m_DirtyAABB: 0
---- !u!1 &2157046097997731443
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046097997731440}
-  m_Layer: 0
-  m_Name: calf_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046097997731440
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046097997731443}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.04836838, y: -0.0189672, z: 0.12562005, w: 0.9907171}
-  m_LocalPosition: {x: 0.15457395, y: -0.0043343264, z: -0.0016690687}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2157046097415955045}
-  m_Father: {fileID: 2157046097615537289}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046098004903900
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046098004903901}
-  - component: {fileID: 2157046098004903714}
-  m_Layer: 0
-  m_Name: Body12
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2157046098004903901
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046098004903900}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046098004903714
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046098004903900}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300062, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: -0.0014484227, y: -0.10346103, z: 0.46982288}
-    m_Extent: {x: 0.5383637, y: 0.60449076, z: 0.5381963}
-  m_DirtyAABB: 0
---- !u!1 &2157046098027138482
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046098027138483}
-  m_Layer: 0
-  m_Name: lowerarm_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046098027138483
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046098027138482}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.000000004030596, y: 0.0000000053592744, z: 0.683239, w: 0.7301948}
-  m_LocalPosition: {x: 0.21657263, y: -0.011759994, z: 1.2789769e-15}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2157046098051586499}
-  m_Father: {fileID: 2157046098389901345}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046098029532668
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046098029532669}
-  m_Layer: 0
-  m_Name: upperarm_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046098029532669
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046098029532668}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.094246596, y: -0.42969748, z: 0.1853828, w: 0.8786984}
-  m_LocalPosition: {x: -0.104934864, y: 0.000007840081, z: -0.0066577005}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2157046098176342394}
-  m_Father: {fileID: 2157046097102626820}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046098051586498
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046098051586499}
-  m_Layer: 0
-  m_Name: hand_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046098051586499
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046098051586498}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.79253304, y: -0.32171422, z: 0.10234816, w: 0.50785464}
-  m_LocalPosition: {x: 0.25676566, y: 0.0058458224, z: -1.508782e-10}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046098238889439}
-  - {fileID: 1509944659781667751}
-  - {fileID: 5447931079856381715}
-  - {fileID: 7309651607474143062}
-  - {fileID: 1416820251381758304}
-  - {fileID: 6230609969808532733}
-  - {fileID: 4859116730437903325}
-  - {fileID: 6851432739259148266}
-  - {fileID: 1295365205838893994}
-  - {fileID: 2914284825439349230}
-  - {fileID: 9096785062607884852}
-  - {fileID: 6082940367156102425}
-  - {fileID: 4799138432823119025}
-  - {fileID: 748935095315254582}
-  - {fileID: 643212804847895770}
-  - {fileID: 2592056586893115982}
-  - {fileID: 8314838422372595480}
-  - {fileID: 3481062188485462049}
-  - {fileID: 1375819734126365222}
-  - {fileID: 6917227880644008069}
-  - {fileID: 3965906240577453091}
-  m_Father: {fileID: 2157046098027138483}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046098118469735
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046098118469732}
-  - component: {fileID: 2157046098118469733}
-  m_Layer: 0
-  m_Name: Body05
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2157046098118469732
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046098118469735}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046098118469733
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046098118469735}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300048, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: -0.0001642108, y: -0.072054684, z: 0.4943595}
-    m_Extent: {x: 0.72779393, y: 0.6037213, z: 0.56695795}
-  m_DirtyAABB: 0
---- !u!1 &2157046098133352750
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046098133352751}
-  m_Layer: 0
-  m_Name: clavicle_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046098133352751
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046098133352750}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.7295103, y: 0.017211089, z: 0.6749811, w: -0.10917408}
-  m_LocalPosition: {x: -0.004090603, y: 0.0074894815, z: 0.095309295}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2157046098389901345}
-  m_Father: {fileID: 2157046098175326834}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046098139437975
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046098139437972}
-  m_Layer: 0
-  m_Name: ball_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046098139437972
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046098139437975}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.0030611525, y: -0.008212709, z: 0.7100026, w: 0.70414454}
-  m_LocalPosition: {x: 0.020676011, y: -0.17323646, z: 0.00075461436}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097415955045}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046098153319689
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046098153319694}
+  - component: {fileID: 1848859554969393590}
   m_Layer: 0
   m_Name: neck_01
   m_TagString: Untagged
@@ -5652,23 +448,23 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &2157046098153319694
+--- !u!4 &1848859554969393590
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046098153319689}
+  m_GameObject: {fileID: 680322541069872126}
   serializedVersion: 2
   m_LocalRotation: {x: -2.4484968e-17, y: 5.4499794e-17, z: 0.18672618, w: 0.982412}
   m_LocalPosition: {x: -0.15594241, y: -0.028345099, z: 2.6297152e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 2157046097434715592}
-  m_Father: {fileID: 2157046098175326834}
+  - {fileID: 705103427817208690}
+  m_Father: {fileID: 8598222625752667699}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046098175326829
+--- !u!1 &712802407257123232
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -5676,194 +472,86 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2157046098175326834}
+  - component: {fileID: 6524410901166697274}
+  - component: {fileID: 4531949249098796545}
   m_Layer: 0
-  m_Name: spine_03
+  m_Name: Rig 1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &2157046098175326834
+--- !u!4 &6524410901166697274
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046098175326829}
+  m_GameObject: {fileID: 712802407257123232}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.04316875, y: -0.006253804, z: -0.0400267, w: 0.9982461}
-  m_LocalPosition: {x: -0.1342877, y: 0.0071493695, z: 6.203883e-17}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.329, y: 0, z: 4.8}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098153319694}
-  m_Father: {fileID: 2157046096950244109}
+  - {fileID: 8260887543115385056}
+  m_Father: {fileID: 3874544495950623930}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046098176342389
-GameObject:
+--- !u!114 &4531949249098796545
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046098176342394}
-  m_Layer: 0
-  m_Name: lowerarm_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046098176342394
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046098176342389}
-  serializedVersion: 2
-  m_LocalRotation: {x: 2.1734088e-15, y: -9.992447e-15, z: 0.21362603, w: 0.97691554}
-  m_LocalPosition: {x: -0.21657251, y: 0.011759994, z: 4.2632563e-16}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2157046098258846160}
-  m_Father: {fileID: 2157046098029532669}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046098191101140
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046098191101141}
-  - component: {fileID: 2157046098191101146}
-  m_Layer: 0
-  m_Name: Head06
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2157046098191101141
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046098191101140}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 1.5731856, z: -1.2783267}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046098191101146
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046098191101140}
+  m_GameObject: {fileID: 712802407257123232}
   m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300010, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: -0.008976102, y: -0.08510536, z: 1.3509095}
-    m_Extent: {x: 0.5043667, y: 0.6201055, z: 0.6696159}
-  m_DirtyAABB: 0
---- !u!1 &2157046098238889438
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 70b342d8ce5c2fd48b8fa3147d48d1d1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 0
+  m_Effectors:
+  - m_Transform: {fileID: 9211380619938324221}
+    m_Style:
+      shape: {fileID: 4300000, guid: 687b70eb9c49243639f9379f6965034f, type: 2}
+      color: {r: 1, g: 0, b: 0, a: 0.5}
+      size: 1.19
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+  - m_Transform: {fileID: 0}
+    m_Style:
+      shape: {fileID: 4300000, guid: 687b70eb9c49243639f9379f6965034f, type: 2}
+      color: {r: 0.38412246, g: 0.40407628, b: 0.9811321, a: 0.5}
+      size: -0.95
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+  - m_Transform: {fileID: 0}
+    m_Style:
+      shape: {fileID: 4300000, guid: 687b70eb9c49243639f9379f6965034f, type: 2}
+      color: {r: 0.38412246, g: 0.40407628, b: 0.9811321, a: 0.5}
+      size: -0.95
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+  - m_Transform: {fileID: 0}
+    m_Style:
+      shape: {fileID: 4300000, guid: 687b70eb9c49243639f9379f6965034f, type: 2}
+      color: {r: 0.38412246, g: 0.40407628, b: 0.9811321, a: 0.5}
+      size: -0.95
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+  - m_Transform: {fileID: 0}
+    m_Style:
+      shape: {fileID: 4300000, guid: 687b70eb9c49243639f9379f6965034f, type: 2}
+      color: {r: 0.38412246, g: 0.40407628, b: 0.9811321, a: 0.5}
+      size: -0.95
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+--- !u!1 &798549006262798705
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -5871,337 +559,8 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2157046098238889439}
-  m_Layer: 0
-  m_Name: thumb_01_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046098238889439
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046098238889438}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.76375103, y: -0.55042547, z: -0.1673881, w: 0.29274115}
-  m_LocalPosition: {x: 0.060496587, y: -0.026371378, z: 0.057738286}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2157046098458972418}
-  m_Father: {fileID: 2157046098051586499}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046098258846163
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046098258846160}
-  m_Layer: 0
-  m_Name: hand_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046098258846160
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046098258846163}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.87721777, y: 0.100944154, z: -0.25952908, w: -0.39108044}
-  m_LocalPosition: {x: -0.25676548, y: -0.005845819, z: -2.842171e-16}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096685411570}
-  - {fileID: 8352545393611895946}
-  - {fileID: 845869089450639126}
-  - {fileID: 470268200330092199}
-  - {fileID: 8568958832614626854}
-  - {fileID: 6381257622104516069}
-  m_Father: {fileID: 2157046098176342394}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046098261556477
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046098261556418}
-  - component: {fileID: 2157046098261556419}
-  m_Layer: 0
-  m_Name: Head20
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2157046098261556418
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046098261556477}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 1.3442874, z: -1.3397256}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046098261556419
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046098261556477}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300038, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: -0.0059431493, y: -0.0030331314, z: 1.3116107}
-    m_Extent: {x: 0.47497422, y: 0.49498135, z: 0.5389408}
-  m_DirtyAABB: 0
---- !u!1 &2157046098323454974
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046098323454975}
-  - component: {fileID: 2157046098323454972}
-  m_Layer: 0
-  m_Name: Head09
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2157046098323454975
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046098323454974}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046098323454972
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046098323454974}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300016, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: -0.011919826, y: -0.22076762, z: 1.3220799}
-    m_Extent: {x: 0.46057934, y: 0.59116954, z: 0.54941}
-  m_DirtyAABB: 0
---- !u!1 &2157046098345701010
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046098345701011}
-  - component: {fileID: 2157046098345701008}
+  - component: {fileID: 7305884043309961793}
+  - component: {fileID: 6969834579103128696}
   m_Layer: 0
   m_Name: Body11
   m_TagString: Untagged
@@ -6209,28 +568,28 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 0
---- !u!4 &2157046098345701011
+--- !u!4 &7305884043309961793
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046098345701010}
+  m_GameObject: {fileID: 798549006262798705}
   serializedVersion: 2
   m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 2157046097115747058}
+  m_Father: {fileID: 3874544495950623930}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046098345701008
+--- !u!137 &6969834579103128696
 SkinnedMeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046098345701010}
+  m_GameObject: {fileID: 798549006262798705}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -6274,54 +633,54 @@ SkinnedMeshRenderer:
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: 4300060, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
   m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
+  m_RootBone: {fileID: 8492314803017277401}
   m_AABB:
     m_Center: {x: 0.0012907982, y: -0.08116746, z: 0.44481882}
     m_Extent: {x: 0.5441053, y: 0.60715514, z: 0.5131923}
   m_DirtyAABB: 0
---- !u!1 &2157046098362991002
+--- !u!1 &810955713710243503
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -6329,162 +688,86 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2157046098362991003}
-  - component: {fileID: 2157046098362991000}
+  - component: {fileID: 4854119414348150365}
+  - component: {fileID: 2193794491484244432}
   m_Layer: 0
-  m_Name: Head07
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2157046098362991003
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046098362991002}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 1.3646253, z: -1.2892855}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046098362991000
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046098362991002}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300012, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: -0.006914139, y: -0.036803737, z: 1.2683241}
-    m_Extent: {x: 1.128058, y: 0.46736038, z: 0.5830121}
-  m_DirtyAABB: 0
---- !u!1 &2157046098365232244
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2157046098365232245}
-  m_Layer: 0
-  m_Name: pelvis
+  m_Name: lowerarm_rAnim
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &2157046098365232245
+--- !u!4 &4854119414348150365
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046098365232244}
+  m_GameObject: {fileID: 810955713710243503}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.08801344, y: 0.7016079, z: 0.08801344, w: 0.7016079}
-  m_LocalPosition: {x: -1.0845211e-17, y: 0.01821081, z: 0.33987784}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.329, y: 5.27, z: 4.8}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046096577505114}
-  m_Father: {fileID: 2157046097784970231}
+  - {fileID: 4163629243762040412}
+  m_Father: {fileID: 5201649495285787456}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046098372877621
+--- !u!114 &2193794491484244432
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 810955713710243503}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3c430f382484144e925c097c2d33cfe, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 0
+  m_Data:
+    m_ConstrainedObject: {fileID: 5902382403927227889}
+    m_SourceObjects:
+      m_Length: 1
+      m_Item0:
+        transform: {fileID: 9211380619938324221}
+        weight: 1
+      m_Item1:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item2:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item3:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item4:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item5:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item6:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item7:
+        transform: {fileID: 0}
+        weight: 0
+    m_Offset: {x: 0, y: 0, z: 0}
+    m_MinLimit: -180
+    m_MaxLimit: 180
+    m_AimAxis: 0
+    m_UpAxis: 2
+    m_WorldUpType: 0
+    m_WorldUpObject: {fileID: 0}
+    m_WorldUpAxis: 2
+    m_MaintainOffset: 0
+    m_ConstrainedAxes:
+      x: 1
+      y: 1
+      z: 1
+--- !u!1 &878033160646220618
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -6492,37 +775,69 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2157046098372877626}
-  - component: {fileID: 2157046098372877627}
+  - component: {fileID: 8887427830417507289}
   m_Layer: 0
-  m_Name: Head13
+  m_Name: upperarm_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2157046098372877626
+  m_IsActive: 1
+--- !u!4 &8887427830417507289
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046098372877621}
+  m_GameObject: {fileID: 878033160646220618}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.094246596, y: -0.42969748, z: 0.1853828, w: 0.8786984}
+  m_LocalPosition: {x: -0.104934864, y: 0.000007840081, z: -0.0066577005}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5060711278442035981}
+  m_Father: {fileID: 4523454433111889778}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &990277058234112089
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1695844588078778786}
+  - component: {fileID: 480616889604468639}
+  m_Layer: 0
+  m_Name: Body03
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1695844588078778786
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 990277058234112089}
   serializedVersion: 2
   m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 2157046097115747058}
+  m_Father: {fileID: 3874544495950623930}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046098372877627
+--- !u!137 &480616889604468639
 SkinnedMeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046098372877621}
+  m_GameObject: {fileID: 990277058234112089}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -6539,7 +854,7 @@ SkinnedMeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
+  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -6564,56 +879,56 @@ SkinnedMeshRenderer:
   m_Quality: 0
   m_UpdateWhenOffscreen: 0
   m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300024, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Mesh: {fileID: 4300044, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
   m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
+  m_RootBone: {fileID: 8492314803017277401}
   m_AABB:
-    m_Center: {x: -0.0076768994, y: -0.06620464, z: 1.2751006}
-    m_Extent: {x: 0.40579715, y: 0.4243664, z: 0.50243056}
+    m_Center: {x: -0.004300624, y: -0.08930412, z: 0.48370504}
+    m_Extent: {x: 0.51579297, y: 0.6187875, z: 0.5644741}
   m_DirtyAABB: 0
---- !u!1 &2157046098389901344
+--- !u!1 &1038417848752637375
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -6621,31 +936,31 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2157046098389901345}
+  - component: {fileID: 3414432838674233775}
   m_Layer: 0
-  m_Name: upperarm_r
+  m_Name: index_01_l
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &2157046098389901345
+--- !u!4 &3414432838674233775
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046098389901344}
+  m_GameObject: {fileID: 1038417848752637375}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.1359213, y: -0.4692266, z: -0.21716502, w: 0.8450984}
-  m_LocalPosition: {x: 0.10493461, y: -0.000007777511, z: 0.006657781}
+  m_LocalRotation: {x: 0.051915236, y: -0.008414891, z: -0.43112874, w: 0.90075636}
+  m_LocalPosition: {x: -0.12400577, y: -0.014340727, z: -0.043471765}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 2157046098027138483}
-  m_Father: {fileID: 2157046098133352751}
+  - {fileID: 8146382468678208126}
+  m_Father: {fileID: 5575222440375443504}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046098390396142
+--- !u!1 &1139275884623626030
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -6653,128 +968,54 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2157046098390396143}
-  - component: {fileID: 2157046098390396140}
+  - component: {fileID: 5201649495285787456}
+  - component: {fileID: 9155258664764592767}
   m_Layer: 0
-  m_Name: Head16
+  m_Name: Rig 5
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &2157046098390396143
+  m_IsActive: 1
+--- !u!4 &5201649495285787456
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046098390396142}
+  m_GameObject: {fileID: 1139275884623626030}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 1.4729636, z: -1.180576}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -5.27, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2157046097115747058}
+  m_Children:
+  - {fileID: 4854119414348150365}
+  m_Father: {fileID: 3874544495950623930}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046098390396140
-SkinnedMeshRenderer:
+--- !u!114 &9155258664764592767
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046098390396142}
+  m_GameObject: {fileID: 1139275884623626030}
   m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: 4300030, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
-  m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
-  m_AABB:
-    m_Center: {x: -0.009891987, y: -0.14689176, z: 1.296374}
-    m_Extent: {x: 0.5472559, y: 0.49178916, z: 0.52370393}
-  m_DirtyAABB: 0
---- !u!1 &2157046098412595018
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 70b342d8ce5c2fd48b8fa3147d48d1d1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 1
+  m_Effectors:
+  - m_Transform: {fileID: 4163629243762040412}
+    m_Style:
+      shape: {fileID: 4300000, guid: e050c2b16fe384bd994474655a4b4968, type: 2}
+      color: {r: 1, g: 0, b: 0, a: 0.5}
+      size: 1
+      position: {x: 0, y: 0, z: 0}
+      rotation: {x: 0, y: 0, z: 0}
+    m_Visible: 1
+--- !u!1 &1144192692214345160
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -6782,31 +1023,31 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2157046098412595019}
+  - component: {fileID: 3387684809064655610}
   m_Layer: 0
-  m_Name: index_02_r
+  m_Name: ring_01_r
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &2157046098412595019
+--- !u!4 &3387684809064655610
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046098412595018}
+  m_GameObject: {fileID: 1144192692214345160}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.022851547, y: 0.0023930725, z: -0.38710564, w: 0.92174906}
-  m_LocalPosition: {x: 0.08471746, y: 0.0113322195, z: 0.0045710607}
+  m_LocalRotation: {x: -0.05282559, y: 0.00015425438, z: -0.8500691, w: 0.52401525}
+  m_LocalPosition: {x: 0.12707186, y: 0.012645532, z: -0.041310944}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 2157046096436678067}
-  m_Father: {fileID: 2157046096850852898}
+  - {fileID: 1218629467550353174}
+  m_Father: {fileID: 5914098565606461513}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2157046098446638453
+--- !u!1 &1223214939894188389
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -6814,8 +1055,8 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2157046098446638458}
-  - component: {fileID: 2157046098446638459}
+  - component: {fileID: 1538587900740975912}
+  - component: {fileID: 7068871264475190001}
   m_Layer: 0
   m_Name: Body04
   m_TagString: Untagged
@@ -6823,28 +1064,28 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 0
---- !u!4 &2157046098446638458
+--- !u!4 &1538587900740975912
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046098446638453}
+  m_GameObject: {fileID: 1223214939894188389}
   serializedVersion: 2
   m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 2157046097115747058}
+  m_Father: {fileID: 3874544495950623930}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!137 &2157046098446638459
+--- !u!137 &7068871264475190001
 SkinnedMeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046098446638453}
+  m_GameObject: {fileID: 1223214939894188389}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -6888,54 +1129,54 @@ SkinnedMeshRenderer:
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: 4300046, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
   m_Bones:
-  - {fileID: 2157046097784970231}
-  - {fileID: 2157046098365232245}
-  - {fileID: 2157046096514618575}
-  - {fileID: 2157046096950244109}
-  - {fileID: 2157046098175326834}
-  - {fileID: 2157046098153319694}
-  - {fileID: 2157046097434715592}
-  - {fileID: 2157046097102626820}
-  - {fileID: 2157046098029532669}
-  - {fileID: 2157046098176342394}
-  - {fileID: 2157046098258846160}
-  - {fileID: 2157046096685411570}
-  - {fileID: 2157046097046777753}
-  - {fileID: 2157046096978929487}
-  - {fileID: 2157046096980991889}
-  - {fileID: 2157046096874381998}
-  - {fileID: 2157046096438143781}
-  - {fileID: 2157046096921138189}
-  - {fileID: 2157046096746755582}
-  - {fileID: 2157046096479809260}
-  - {fileID: 2157046098133352751}
-  - {fileID: 2157046098389901345}
-  - {fileID: 2157046098027138483}
-  - {fileID: 2157046098051586499}
-  - {fileID: 2157046098238889439}
-  - {fileID: 2157046098458972418}
-  - {fileID: 2157046097101375842}
-  - {fileID: 2157046096850852898}
-  - {fileID: 2157046098412595019}
-  - {fileID: 2157046096436678067}
-  - {fileID: 2157046097186492382}
-  - {fileID: 2157046097289563942}
-  - {fileID: 2157046097523559931}
-  - {fileID: 2157046097615537289}
-  - {fileID: 2157046097997731440}
-  - {fileID: 2157046097415955045}
-  - {fileID: 2157046098139437972}
-  - {fileID: 2157046096577505114}
-  - {fileID: 2157046096909014722}
-  - {fileID: 2157046096363307895}
-  - {fileID: 2157046096952503185}
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
   m_BlendShapeWeights: []
-  m_RootBone: {fileID: 2157046097784970231}
+  m_RootBone: {fileID: 8492314803017277401}
   m_AABB:
     m_Center: {x: -0.0017743707, y: -0.097151786, z: 0.4509651}
     m_Extent: {x: 0.66935813, y: 0.610914, z: 0.5502128}
   m_DirtyAABB: 0
---- !u!1 &2157046098458972477
+--- !u!1 &1372882942246494168
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -6943,31 +1184,449 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2157046098458972418}
+  - component: {fileID: 9018921666353916023}
+  - component: {fileID: 6684100899183379269}
   m_Layer: 0
-  m_Name: thumb_02_r
+  m_Name: Body18
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2157046098458972418
+  m_IsActive: 0
+--- !u!4 &9018921666353916023
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2157046098458972477}
+  m_GameObject: {fileID: 1372882942246494168}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.212404, y: -0.37523955, z: -0.60814404, w: 0.6665138}
-  m_LocalPosition: {x: 0.075063586, y: -0.0011268383, z: -0.00038413808}
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &6684100899183379269
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1372882942246494168}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300074, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: 0.03171587, y: -0.097294, z: 0.4642473}
+    m_Extent: {x: 0.60155445, y: 0.61079764, z: 0.53185666}
+  m_DirtyAABB: 0
+--- !u!1 &1410392239603405079
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2877428044612164834}
+  - component: {fileID: 4002576391442461194}
+  m_Layer: 0
+  m_Name: Head06
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &2877428044612164834
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1410392239603405079}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 1.5731856, z: -1.2783267}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &4002576391442461194
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1410392239603405079}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300010, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: -0.008976102, y: -0.08510536, z: 1.3509095}
+    m_Extent: {x: 0.5043667, y: 0.6201055, z: 0.6696159}
+  m_DirtyAABB: 0
+--- !u!1 &1431608330708942748
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4818627931214187240}
+  m_Layer: 0
+  m_Name: ring_03_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4818627931214187240
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1431608330708942748}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: -0.00971795, z: -0, w: 0.9999528}
+  m_LocalPosition: {x: 0.070884004, y: 0.010713819, z: 0.0032234276}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1218629467550353174}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1580391421228595334
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 867491537974610657}
+  - component: {fileID: 5098244099476728361}
+  m_Layer: 0
+  m_Name: Head16
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &867491537974610657
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1580391421228595334}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 1.4729636, z: -1.180576}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &5098244099476728361
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1580391421228595334}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300030, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: -0.009891987, y: -0.14689176, z: 1.296374}
+    m_Extent: {x: 0.5472559, y: 0.49178916, z: 0.52370393}
+  m_DirtyAABB: 0
+--- !u!1 &1643024969360060682
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3753088472699768561}
+  m_Layer: 0
+  m_Name: clavicle_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3753088472699768561
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1643024969360060682}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.7295103, y: 0.017211089, z: 0.6749811, w: -0.10917408}
+  m_LocalPosition: {x: -0.004090603, y: 0.0074894815, z: 0.095309295}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 2157046097101375842}
-  m_Father: {fileID: 2157046098238889439}
+  - {fileID: 7311588285887538455}
+  m_Father: {fileID: 8598222625752667699}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &3252360033825524786
+--- !u!1 &1822282798663895375
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -6975,75 +1634,31 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 4452459474808381925}
-  - component: {fileID: 7241046244089165072}
-  m_Layer: 7
-  m_Name: Monster Scan
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &4452459474808381925
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3252360033825524786}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 3699101498662529524}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &7241046244089165072
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3252360033825524786}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 22487aea474137f48be4059e2cecdfbf, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_TargetGroup: {fileID: 5825741382810516601}
---- !u!1 &3799197406614388647
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8407424675788172468}
+  - component: {fileID: 5906552103748992065}
   m_Layer: 0
-  m_Name: Target
+  m_Name: spine_02
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &8407424675788172468
+--- !u!4 &5906552103748992065
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3799197406614388647}
+  m_GameObject: {fileID: 1822282798663895375}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0.13051149, y: 0.0019590356, z: -0.11750843, w: 0.98445654}
+  m_LocalPosition: {x: -0.14993994, y: 0.02061772, z: 4.3672006e-17}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 5683681569832718465}
+  m_Children:
+  - {fileID: 8598222625752667699}
+  m_Father: {fileID: 5399429416690821740}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &4113186581549217694
+--- !u!1 &1961367383870648407
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -7051,8 +1666,40 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 4141789439425173366}
-  - component: {fileID: 1272205581764547985}
+  - component: {fileID: 3212172166270237851}
+  m_Layer: 0
+  m_Name: thigh_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3212172166270237851
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1961367383870648407}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.025237134, y: 0.08581908, z: -0.2812596, w: 0.9554534}
+  m_LocalPosition: {x: 0.011850943, y: -0.0066443863, z: -0.11042425}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6219218383762812829}
+  m_Father: {fileID: 4205418828267842209}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2053045265031491754
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6014408480055892977}
+  - component: {fileID: 7517856810503511536}
   m_Layer: 7
   m_Name: GameObject
   m_TagString: Untagged
@@ -7060,35 +1707,35 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &4141789439425173366
+--- !u!4 &6014408480055892977
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4113186581549217694}
+  m_GameObject: {fileID: 2053045265031491754}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 3699101498662529524}
+  m_Father: {fileID: 6033035017459168276}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1272205581764547985
+--- !u!114 &7517856810503511536
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4113186581549217694}
+  m_GameObject: {fileID: 2053045265031491754}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 82086ece39dc9774b9b2dda665b01ee7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  bodyTrans: {fileID: 2157046097784970231}
---- !u!1 &4553689123833333373
+  bodyTrans: {fileID: 8492314803017277401}
+--- !u!1 &2055347086678692813
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -7096,128 +1743,38 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 998594297420083682}
-  - component: {fileID: 3806700233998148600}
+  - component: {fileID: 9020029325738588377}
+  - component: {fileID: 2058591291632975355}
   m_Layer: 0
-  m_Name: Rig 1
+  m_Name: Hand_lAnim
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &998594297420083682
+--- !u!4 &9020029325738588377
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4553689123833333373}
+  m_GameObject: {fileID: 2055347086678692813}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.329, y: 0, z: 4.8}
+  m_LocalPosition: {x: -0.329, y: 5.27, z: 4.8}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 5683681569832718465}
-  - {fileID: 9045070188613159137}
-  - {fileID: 4410742055597872155}
-  - {fileID: 289401352103364691}
-  - {fileID: 3268191801982855446}
-  m_Father: {fileID: 2157046097115747058}
+  - {fileID: 5437207413694491365}
+  m_Father: {fileID: 2850555212391482384}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &3806700233998148600
+--- !u!114 &2058591291632975355
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4553689123833333373}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 70b342d8ce5c2fd48b8fa3147d48d1d1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 1
-  m_Effectors:
-  - m_Transform: {fileID: 8407424675788172468}
-    m_Style:
-      shape: {fileID: 4300000, guid: 687b70eb9c49243639f9379f6965034f, type: 2}
-      color: {r: 1, g: 0, b: 0, a: 0.5}
-      size: 1.19
-      position: {x: 0, y: 0, z: 0}
-      rotation: {x: 0, y: 0, z: 0}
-    m_Visible: 1
-  - m_Transform: {fileID: 0}
-    m_Style:
-      shape: {fileID: 4300000, guid: 687b70eb9c49243639f9379f6965034f, type: 2}
-      color: {r: 0.38412246, g: 0.40407628, b: 0.9811321, a: 0.5}
-      size: -0.95
-      position: {x: 0, y: 0, z: 0}
-      rotation: {x: 0, y: 0, z: 0}
-    m_Visible: 1
-  - m_Transform: {fileID: 0}
-    m_Style:
-      shape: {fileID: 4300000, guid: 687b70eb9c49243639f9379f6965034f, type: 2}
-      color: {r: 0.38412246, g: 0.40407628, b: 0.9811321, a: 0.5}
-      size: -0.95
-      position: {x: 0, y: 0, z: 0}
-      rotation: {x: 0, y: 0, z: 0}
-    m_Visible: 1
-  - m_Transform: {fileID: 0}
-    m_Style:
-      shape: {fileID: 4300000, guid: 687b70eb9c49243639f9379f6965034f, type: 2}
-      color: {r: 0.38412246, g: 0.40407628, b: 0.9811321, a: 0.5}
-      size: -0.95
-      position: {x: 0, y: 0, z: 0}
-      rotation: {x: 0, y: 0, z: 0}
-    m_Visible: 1
-  - m_Transform: {fileID: 0}
-    m_Style:
-      shape: {fileID: 4300000, guid: 687b70eb9c49243639f9379f6965034f, type: 2}
-      color: {r: 0.38412246, g: 0.40407628, b: 0.9811321, a: 0.5}
-      size: -0.95
-      position: {x: 0, y: 0, z: 0}
-      rotation: {x: 0, y: 0, z: 0}
-    m_Visible: 1
---- !u!1 &4889801877070804989
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 9045070188613159137}
-  - component: {fileID: 5420977427080564922}
-  m_Layer: 0
-  m_Name: Hand_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &9045070188613159137
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4889801877070804989}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 998594297420083682}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &5420977427080564922
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4889801877070804989}
+  m_GameObject: {fileID: 2055347086678692813}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: e3c430f382484144e925c097c2d33cfe, type: 3}
@@ -7225,390 +1782,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Weight: 0
   m_Data:
-    m_ConstrainedObject: {fileID: 2157046098051586499}
+    m_ConstrainedObject: {fileID: 5575222440375443504}
     m_SourceObjects:
       m_Length: 1
       m_Item0:
-        transform: {fileID: 8407424675788172468}
-        weight: 1
-      m_Item1:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item2:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item3:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item4:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item5:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item6:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item7:
-        transform: {fileID: 0}
-        weight: 0
-    m_Offset: {x: 0, y: 0, z: 0}
-    m_MinLimit: -31
-    m_MaxLimit: -4
-    m_AimAxis: 0
-    m_UpAxis: 4
-    m_WorldUpType: 0
-    m_WorldUpObject: {fileID: 0}
-    m_WorldUpAxis: 2
-    m_MaintainOffset: 0
-    m_ConstrainedAxes:
-      x: 1
-      y: 1
-      z: 1
---- !u!1 &5077166633909043626
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3268191801982855446}
-  - component: {fileID: 4347952008001651041}
-  m_Layer: 0
-  m_Name: lowerarm_r
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3268191801982855446
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5077166633909043626}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 998594297420083682}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &4347952008001651041
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5077166633909043626}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e3c430f382484144e925c097c2d33cfe, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 0
-  m_Data:
-    m_ConstrainedObject: {fileID: 2157046098027138483}
-    m_SourceObjects:
-      m_Length: 1
-      m_Item0:
-        transform: {fileID: 8407424675788172468}
-        weight: 1
-      m_Item1:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item2:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item3:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item4:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item5:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item6:
-        transform: {fileID: 0}
-        weight: 0
-      m_Item7:
-        transform: {fileID: 0}
-        weight: 0
-    m_Offset: {x: 0, y: 0, z: 0}
-    m_MinLimit: -180
-    m_MaxLimit: 180
-    m_AimAxis: 0
-    m_UpAxis: 2
-    m_WorldUpType: 0
-    m_WorldUpObject: {fileID: 0}
-    m_WorldUpAxis: 2
-    m_MaintainOffset: 0
-    m_ConstrainedAxes:
-      x: 1
-      y: 1
-      z: 1
---- !u!1 &5427188757696776923
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6849201056815116209}
-  - component: {fileID: 5825741382810516601}
-  m_Layer: 0
-  m_Name: lockOnCam Group
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6849201056815116209
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5427188757696776923}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: -5.27, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 3699101498662529524}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &5825741382810516601
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5427188757696776923}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e5eb80d8e62d9d145bb50fb783c0f731, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  PositionMode: 0
-  RotationMode: 0
-  UpdateMethod: 2
-  Targets: []
-  m_LegacyTargets: []
---- !u!1 &5961379174359455997
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3819367472279800127}
-  - component: {fileID: 7011079490586622914}
-  - component: {fileID: 4412990491384939345}
-  - component: {fileID: 1134880827442298119}
-  m_Layer: 0
-  m_Name: LookAtCam
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3819367472279800127
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5961379174359455997}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.4690681, y: -0.3359602, z: 0.19893257, w: 0.79216903}
-  m_LocalPosition: {x: 2.72, y: 2.25, z: -2.63}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 3699101498662529524}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &7011079490586622914
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5961379174359455997}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f9dfa5b682dcd46bda6128250e975f58, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  Priority:
-    Enabled: 1
-    m_Value: 0
-  OutputChannel: 1
-  StandbyUpdate: 2
-  m_StreamingVersion: 20241001
-  m_LegacyPriority: 0
-  Target:
-    TrackingTarget: {fileID: 6849201056815116209}
-    LookAtTarget: {fileID: 0}
-    CustomLookAtTarget: 0
-  Lens:
-    FieldOfView: 60.000004
-    OrthographicSize: 10
-    NearClipPlane: 0.1
-    FarClipPlane: 5000
-    Dutch: 0
-    ModeOverride: 0
-    PhysicalProperties:
-      GateFit: 2
-      SensorSize: {x: 21.946, y: 16.002}
-      LensShift: {x: 0, y: 0}
-      FocusDistance: 10
-      Iso: 200
-      ShutterSpeed: 0.005
-      Aperture: 16
-      BladeCount: 5
-      Curvature: {x: 2, y: 11}
-      BarrelClipping: 0.25
-      Anamorphism: 0
-  BlendHint: 0
---- !u!114 &4412990491384939345
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5961379174359455997}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f38bda98361e1de48a4ca2bd86ea3c17, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  Composition:
-    ScreenPosition: {x: 0, y: 0}
-    DeadZone:
-      Enabled: 0
-      Size: {x: 0.2, y: 0.2}
-    HardLimits:
-      Enabled: 0
-      Size: {x: 0.8, y: 0.8}
-      Offset: {x: 0, y: 0}
-  CenterOnActivate: 1
-  TargetOffset: {x: 0, y: 0.62, z: 0}
-  Damping: {x: 0.5, y: 0.5}
-  Lookahead:
-    Enabled: 0
-    Time: 0
-    Smoothing: 0
-    IgnoreY: 0
---- !u!114 &1134880827442298119
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5961379174359455997}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4eb4843bae7d24943842ea23130dcd55, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  FramingMode: 2
-  FramingSize: 0.8
-  CenterOffset: {x: 0, y: 0}
-  Damping: 2
-  SizeAdjustment: 2
-  LateralAdjustment: 0
-  FovRange: {x: 1, y: 100}
-  DollyRange: {x: -100, y: 100}
-  OrthoSizeRange: {x: 1, y: 1000}
---- !u!1 &5994647669860166002
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6387495218651356608}
-  m_Layer: 7
-  m_Name: root
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6387495218651356608
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5994647669860166002}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.99, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 3699101498662529524}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6744242154059502483
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4410742055597872155}
-  - component: {fileID: 6064842056013174442}
-  m_Layer: 0
-  m_Name: Hand_l
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &4410742055597872155
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6744242154059502483}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 998594297420083682}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &6064842056013174442
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6744242154059502483}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e3c430f382484144e925c097c2d33cfe, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Weight: 0
-  m_Data:
-    m_ConstrainedObject: {fileID: 2157046098258846160}
-    m_SourceObjects:
-      m_Length: 1
-      m_Item0:
-        transform: {fileID: 8407424675788172468}
+        transform: {fileID: 9211380619938324221}
         weight: 1
       m_Item1:
         transform: {fileID: 0}
@@ -7644,7 +1822,7 @@ MonoBehaviour:
       x: 1
       y: 1
       z: 1
---- !u!1 &8431082099228877782
+--- !u!1 &2163547915057320771
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -7652,44 +1830,128 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 6437870964944921167}
-  - component: {fileID: 8928931733619069730}
+  - component: {fileID: 8349520580120789455}
+  - component: {fileID: 8356703784268505511}
   m_Layer: 0
-  m_Name: AbilitySystem
+  m_Name: Head02
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6437870964944921167
+  m_IsActive: 0
+--- !u!4 &8349520580120789455
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8431082099228877782}
+  m_GameObject: {fileID: 2163547915057320771}
   serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: -5.27, z: 0}
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 5422319584633030792}
-  m_Father: {fileID: 3699101498662529524}
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &8928931733619069730
-MonoBehaviour:
+--- !u!137 &8356703784268505511
+SkinnedMeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8431082099228877782}
+  m_GameObject: {fileID: 2163547915057320771}
   m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c800aec2fc7201442874e7394c8adc66, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &9012085531027032363
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300002, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: 0.024535194, y: 0.19635624, z: 1.2558525}
+    m_Extent: {x: 0.5006984, y: 0.7457301, z: 0.6284697}
+  m_DirtyAABB: 0
+--- !u!1 &2191322474398196031
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -7697,8 +1959,714 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 5683681569832718465}
-  - component: {fileID: 5572829388407711453}
+  - component: {fileID: 1414832981805400041}
+  - component: {fileID: 476107997500734470}
+  m_Layer: 0
+  m_Name: Head18
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1414832981805400041
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2191322474398196031}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 1.6317652, z: -1.4065672}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &476107997500734470
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2191322474398196031}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300034, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: -0.008751035, y: -0.10532588, z: 1.4909414}
+    m_Extent: {x: 0.7895002, y: 0.69968027, z: 0.7182714}
+  m_DirtyAABB: 0
+--- !u!1 &2254135580723369106
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1218629467550353174}
+  m_Layer: 0
+  m_Name: ring_02_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1218629467550353174
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2254135580723369106}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.011487454, y: 0.008718428, z: -0.6495072, w: 0.76021874}
+  m_LocalPosition: {x: 0.08095703, y: 0.015202765, z: -0.000097014985}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4818627931214187240}
+  m_Father: {fileID: 3387684809064655610}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2508946647924200096
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8242313990430915567}
+  m_Layer: 0
+  m_Name: index_03_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8242313990430915567
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2508946647924200096}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.019108133, y: -0.021374207, z: 0.0004085892, w: 0.99958885}
+  m_LocalPosition: {x: -0.06901584, y: -0.004201027, z: -0.004045686}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8146382468678208126}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2571728356586000165
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3052105946573604569}
+  m_Layer: 0
+  m_Name: thumb_01_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3052105946573604569
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2571728356586000165}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.76375103, y: -0.55042547, z: -0.1673881, w: 0.29274115}
+  m_LocalPosition: {x: 0.060496587, y: -0.026371378, z: 0.057738286}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1155318496298573467}
+  m_Father: {fileID: 5914098565606461513}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2665404698430369819
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2600130595795185846}
+  m_Layer: 0
+  m_Name: thumb_02_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2600130595795185846
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2665404698430369819}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.24762599, y: -0.34194008, z: -0.61408085, w: 0.66683066}
+  m_LocalPosition: {x: -0.075063676, y: 0.0011263808, z: 0.00038358383}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4033362781427830493}
+  m_Father: {fileID: 4432144893256309992}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2681971742786836256
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4432144893256309992}
+  m_Layer: 0
+  m_Name: thumb_01_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4432144893256309992
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2681971742786836256}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.7996904, y: -0.4921358, z: -0.15047257, w: 0.30928236}
+  m_LocalPosition: {x: -0.060496494, y: 0.026370905, z: -0.05773824}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2600130595795185846}
+  m_Father: {fileID: 5575222440375443504}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2730500263709480038
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6219218383762812829}
+  m_Layer: 0
+  m_Name: calf_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6219218383762812829
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2730500263709480038}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.04836838, y: -0.0189672, z: 0.12562005, w: 0.9907171}
+  m_LocalPosition: {x: 0.15457395, y: -0.0043343264, z: -0.0016690687}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 518966291794105451}
+  m_Father: {fileID: 3212172166270237851}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2806623116950620484
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3612848061301910226}
+  m_Layer: 0
+  m_Name: thigh_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3612848061301910226
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2806623116950620484}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.08808675, y: -0.015657831, z: 0.9888635, w: 0.11893094}
+  m_LocalPosition: {x: 0.011850503, y: -0.0066443053, z: 0.110424004}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2378788658461824038}
+  m_Father: {fileID: 4205418828267842209}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2986620515655942774
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5224943072361654219}
+  m_Layer: 0
+  m_Name: index_01_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5224943072361654219
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2986620515655942774}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.05222944, y: -0.0061715096, z: -0.4695172, w: 0.8813555}
+  m_LocalPosition: {x: 0.12400588, y: 0.014340664, z: 0.043471806}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 9031354481043070482}
+  m_Father: {fileID: 5914098565606461513}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2999059805045504880
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8992972022723078433}
+  - component: {fileID: 3910918610706516546}
+  m_Layer: 0
+  m_Name: Body15
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &8992972022723078433
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2999059805045504880}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &3910918610706516546
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2999059805045504880}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300068, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: 0.028638601, y: -0.04786834, z: 0.5093344}
+    m_Extent: {x: 0.7141261, y: 0.67605674, z: 0.5937416}
+  m_DirtyAABB: 0
+--- !u!1 &3011027034686243760
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5902382403927227889}
+  m_Layer: 0
+  m_Name: lowerarm_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5902382403927227889
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3011027034686243760}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.000000004030596, y: 0.0000000053592744, z: 0.683239, w: 0.7301948}
+  m_LocalPosition: {x: 0.21657263, y: -0.011759994, z: 1.2789769e-15}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5914098565606461513}
+  m_Father: {fileID: 7311588285887538455}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3027464646441711849
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 913951962055070540}
+  - component: {fileID: 3430683568204523757}
+  m_Layer: 0
+  m_Name: Body19
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &913951962055070540
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3027464646441711849}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &3430683568204523757
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3027464646441711849}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300076, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: 0.016650587, y: -0.42388144, z: 0.58969605}
+    m_Extent: {x: 0.51655173, y: 0.8531207, z: 0.6580695}
+  m_DirtyAABB: 0
+--- !u!1 &3085608313209650679
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9031354481043070482}
+  m_Layer: 0
+  m_Name: index_02_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &9031354481043070482
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3085608313209650679}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.022851547, y: 0.0023930725, z: -0.38710564, w: 0.92174906}
+  m_LocalPosition: {x: 0.08471746, y: 0.0113322195, z: 0.0045710607}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8887081984817386572}
+  m_Father: {fileID: 5224943072361654219}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3189618109365735820
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8260887543115385056}
+  - component: {fileID: 7115779614092203966}
   m_Layer: 0
   m_Name: HeadAnim
   m_TagString: Untagged
@@ -7706,29 +2674,29 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &5683681569832718465
+--- !u!4 &8260887543115385056
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9012085531027032363}
+  m_GameObject: {fileID: 3189618109365735820}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 8407424675788172468}
-  m_Father: {fileID: 998594297420083682}
+  - {fileID: 9211380619938324221}
+  m_Father: {fileID: 6524410901166697274}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &5572829388407711453
+--- !u!114 &7115779614092203966
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9012085531027032363}
+  m_GameObject: {fileID: 3189618109365735820}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: e3c430f382484144e925c097c2d33cfe, type: 3}
@@ -7736,11 +2704,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Weight: 0
   m_Data:
-    m_ConstrainedObject: {fileID: 2157046097434715592}
+    m_ConstrainedObject: {fileID: 705103427817208690}
     m_SourceObjects:
       m_Length: 1
       m_Item0:
-        transform: {fileID: 8407424675788172468}
+        transform: {fileID: 9211380619938324221}
         weight: 1
       m_Item1:
         transform: {fileID: 0}
@@ -7776,1193 +2744,5394 @@ MonoBehaviour:
       x: 1
       y: 1
       z: 1
---- !u!1001 &49969018829437321
-PrefabInstance:
+--- !u!1 &3214068859459886628
+GameObject:
   m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 2157046098051586499}
-    m_Modifications:
-    - target: {fileID: 5416553806754953150, guid: 2cecb33133bf7b249b23daad68d0df10, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
-    - target: {fileID: 5416553806760229562, guid: 2cecb33133bf7b249b23daad68d0df10, type: 3}
-      propertyPath: m_Name
-      value: SawGunDefault
-      objectReference: {fileID: 0}
-    - target: {fileID: 5416553806760229562, guid: 2cecb33133bf7b249b23daad68d0df10, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5416553806760257178, guid: 2cecb33133bf7b249b23daad68d0df10, type: 3}
-      propertyPath: m_RootOrder
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 5416553806760257178, guid: 2cecb33133bf7b249b23daad68d0df10, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.1693875
-      objectReference: {fileID: 0}
-    - target: {fileID: 5416553806760257178, guid: 2cecb33133bf7b249b23daad68d0df10, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.021226466
-      objectReference: {fileID: 0}
-    - target: {fileID: 5416553806760257178, guid: 2cecb33133bf7b249b23daad68d0df10, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.1543433
-      objectReference: {fileID: 0}
-    - target: {fileID: 5416553806760257178, guid: 2cecb33133bf7b249b23daad68d0df10, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.5024751
-      objectReference: {fileID: 0}
-    - target: {fileID: 5416553806760257178, guid: 2cecb33133bf7b249b23daad68d0df10, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.4988577
-      objectReference: {fileID: 0}
-    - target: {fileID: 5416553806760257178, guid: 2cecb33133bf7b249b23daad68d0df10, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.4993508
-      objectReference: {fileID: 0}
-    - target: {fileID: 5416553806760257178, guid: 2cecb33133bf7b249b23daad68d0df10, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.4993081
-      objectReference: {fileID: 0}
-    - target: {fileID: 5416553806760257178, guid: 2cecb33133bf7b249b23daad68d0df10, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5416553806760257178, guid: 2cecb33133bf7b249b23daad68d0df10, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5416553806760257178, guid: 2cecb33133bf7b249b23daad68d0df10, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 2cecb33133bf7b249b23daad68d0df10, type: 3}
---- !u!4 &5447931079856381715 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5416553806760257178, guid: 2cecb33133bf7b249b23daad68d0df10, type: 3}
-  m_PrefabInstance: {fileID: 49969018829437321}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &465045511941867505
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 2157046098051586499}
-    m_Modifications:
-    - target: {fileID: 1541296155195428663, guid: 7b2284d4a9faf474492e3b11a78a77ca, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
-    - target: {fileID: 1541296155197690359, guid: 7b2284d4a9faf474492e3b11a78a77ca, type: 3}
-      propertyPath: m_Name
-      value: KnifeDefault
-      objectReference: {fileID: 0}
-    - target: {fileID: 1541296155197690359, guid: 7b2284d4a9faf474492e3b11a78a77ca, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1541296155197722071, guid: 7b2284d4a9faf474492e3b11a78a77ca, type: 3}
-      propertyPath: m_RootOrder
-      value: 20
-      objectReference: {fileID: 0}
-    - target: {fileID: 1541296155197722071, guid: 7b2284d4a9faf474492e3b11a78a77ca, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.094
-      objectReference: {fileID: 0}
-    - target: {fileID: 1541296155197722071, guid: 7b2284d4a9faf474492e3b11a78a77ca, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.028
-      objectReference: {fileID: 0}
-    - target: {fileID: 1541296155197722071, guid: 7b2284d4a9faf474492e3b11a78a77ca, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.01
-      objectReference: {fileID: 0}
-    - target: {fileID: 1541296155197722071, guid: 7b2284d4a9faf474492e3b11a78a77ca, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.7080492
-      objectReference: {fileID: 0}
-    - target: {fileID: 1541296155197722071, guid: 7b2284d4a9faf474492e3b11a78a77ca, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.0025578432
-      objectReference: {fileID: 0}
-    - target: {fileID: 1541296155197722071, guid: 7b2284d4a9faf474492e3b11a78a77ca, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.000030159943
-      objectReference: {fileID: 0}
-    - target: {fileID: 1541296155197722071, guid: 7b2284d4a9faf474492e3b11a78a77ca, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.70615846
-      objectReference: {fileID: 0}
-    - target: {fileID: 1541296155197722071, guid: 7b2284d4a9faf474492e3b11a78a77ca, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
-      objectReference: {fileID: 0}
-    - target: {fileID: 1541296155197722071, guid: 7b2284d4a9faf474492e3b11a78a77ca, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1541296155197722071, guid: 7b2284d4a9faf474492e3b11a78a77ca, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 7b2284d4a9faf474492e3b11a78a77ca, type: 3}
---- !u!4 &1375819734126365222 stripped
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2056985541906827850}
+  - component: {fileID: 5498666575537338061}
+  m_Layer: 0
+  m_Name: Head07
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &2056985541906827850
 Transform:
-  m_CorrespondingSourceObject: {fileID: 1541296155197722071, guid: 7b2284d4a9faf474492e3b11a78a77ca, type: 3}
-  m_PrefabInstance: {fileID: 465045511941867505}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1197345129580481405
-PrefabInstance:
   m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3214068859459886628}
   serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 2157046098258846160}
-    m_Modifications:
-    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
-      propertyPath: m_RootOrder
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.067
-      objectReference: {fileID: 0}
-    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.029
-      objectReference: {fileID: 0}
-    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.025
-      objectReference: {fileID: 0}
-    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.49885768
-      objectReference: {fileID: 0}
-    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.50247514
-      objectReference: {fileID: 0}
-    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.49930817
-      objectReference: {fileID: 0}
-    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.49935076
-      objectReference: {fileID: 0}
-    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7383332340980187515, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
-      propertyPath: m_Name
-      value: SMG_LeftDefault
-      objectReference: {fileID: 0}
-    - target: {fileID: 7383332340980187515, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7383332340982194107, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
---- !u!4 &8568958832614626854 stripped
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 1.3646253, z: -1.2892855}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &5498666575537338061
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3214068859459886628}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300012, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: -0.006914139, y: -0.036803737, z: 1.2683241}
+    m_Extent: {x: 1.128058, y: 0.46736038, z: 0.5830121}
+  m_DirtyAABB: 0
+--- !u!1 &3250966541590724857
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1155318496298573467}
+  m_Layer: 0
+  m_Name: thumb_02_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1155318496298573467
 Transform:
-  m_CorrespondingSourceObject: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
-  m_PrefabInstance: {fileID: 1197345129580481405}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1350036955530276787
-PrefabInstance:
   m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3250966541590724857}
   serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 2157046098258846160}
-    m_Modifications:
-    - target: {fileID: 1801837882128536133, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
-    - target: {fileID: 1801837882130305189, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
-      propertyPath: m_RootOrder
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 1801837882130305189, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.093
-      objectReference: {fileID: 0}
-    - target: {fileID: 1801837882130305189, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.017
-      objectReference: {fileID: 0}
-    - target: {fileID: 1801837882130305189, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.019
-      objectReference: {fileID: 0}
-    - target: {fileID: 1801837882130305189, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.4988578
-      objectReference: {fileID: 0}
-    - target: {fileID: 1801837882130305189, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.50247514
-      objectReference: {fileID: 0}
-    - target: {fileID: 1801837882130305189, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.4993081
-      objectReference: {fileID: 0}
-    - target: {fileID: 1801837882130305189, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.49935076
-      objectReference: {fileID: 0}
-    - target: {fileID: 1801837882130305189, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1801837882130305189, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1801837882130305189, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1801837882130795653, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
-      propertyPath: m_Name
-      value: HMG_LeftDefault
-      objectReference: {fileID: 0}
-    - target: {fileID: 1801837882130795653, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
---- !u!4 &845869089450639126 stripped
+  m_LocalRotation: {x: -0.212404, y: -0.37523955, z: -0.60814404, w: 0.6665138}
+  m_LocalPosition: {x: 0.075063586, y: -0.0011268383, z: -0.00038413808}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8732938456802479290}
+  m_Father: {fileID: 3052105946573604569}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3293959919649725146
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3563986922905317837}
+  m_Layer: 0
+  m_Name: ring_03_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3563986922905317837
 Transform:
-  m_CorrespondingSourceObject: {fileID: 1801837882130305189, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
-  m_PrefabInstance: {fileID: 1350036955530276787}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1790287403386175168
-PrefabInstance:
   m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3293959919649725146}
   serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 2157046098051586499}
-    m_Modifications:
-    - target: {fileID: 3506613558081934798, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
-    - target: {fileID: 3506613558083865358, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
-      propertyPath: m_Name
-      value: ChemicalGunDefault
-      objectReference: {fileID: 0}
-    - target: {fileID: 3506613558083865358, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
-      propertyPath: m_RootOrder
-      value: 11
-      objectReference: {fileID: 0}
-    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.075
-      objectReference: {fileID: 0}
-    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.031
-      objectReference: {fileID: 0}
-    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.011
-      objectReference: {fileID: 0}
-    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.5024751
-      objectReference: {fileID: 0}
-    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.49885765
-      objectReference: {fileID: 0}
-    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.4993508
-      objectReference: {fileID: 0}
-    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.49930817
-      objectReference: {fileID: 0}
-    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
---- !u!4 &2914284825439349230 stripped
+  m_LocalRotation: {x: 0, y: -0.00971795, z: -0, w: 0.9999528}
+  m_LocalPosition: {x: -0.07088354, y: -0.010713612, z: -0.0032234166}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2012315593512496057}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3337440325306026196
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3981016198049755183}
+  - component: {fileID: 6985043431180457887}
+  m_Layer: 0
+  m_Name: Body05
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &3981016198049755183
 Transform:
-  m_CorrespondingSourceObject: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
-  m_PrefabInstance: {fileID: 1790287403386175168}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &2329780090782405552
-PrefabInstance:
   m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3337440325306026196}
   serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 2157046098051586499}
-    m_Modifications:
-    - target: {fileID: 4982128866425352390, guid: 77c66d64e7d1a8b458934029d50fcbf1, type: 3}
-      propertyPath: m_Name
-      value: FlameThrowerDefault
-      objectReference: {fileID: 0}
-    - target: {fileID: 4982128866425352390, guid: 77c66d64e7d1a8b458934029d50fcbf1, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4982128866425777382, guid: 77c66d64e7d1a8b458934029d50fcbf1, type: 3}
-      propertyPath: m_RootOrder
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4982128866425777382, guid: 77c66d64e7d1a8b458934029d50fcbf1, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.076
-      objectReference: {fileID: 0}
-    - target: {fileID: 4982128866425777382, guid: 77c66d64e7d1a8b458934029d50fcbf1, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.046
-      objectReference: {fileID: 0}
-    - target: {fileID: 4982128866425777382, guid: 77c66d64e7d1a8b458934029d50fcbf1, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.012
-      objectReference: {fileID: 0}
-    - target: {fileID: 4982128866425777382, guid: 77c66d64e7d1a8b458934029d50fcbf1, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.5024751
-      objectReference: {fileID: 0}
-    - target: {fileID: 4982128866425777382, guid: 77c66d64e7d1a8b458934029d50fcbf1, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.49885765
-      objectReference: {fileID: 0}
-    - target: {fileID: 4982128866425777382, guid: 77c66d64e7d1a8b458934029d50fcbf1, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.4993508
-      objectReference: {fileID: 0}
-    - target: {fileID: 4982128866425777382, guid: 77c66d64e7d1a8b458934029d50fcbf1, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.49930817
-      objectReference: {fileID: 0}
-    - target: {fileID: 4982128866425777382, guid: 77c66d64e7d1a8b458934029d50fcbf1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4982128866425777382, guid: 77c66d64e7d1a8b458934029d50fcbf1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4982128866425777382, guid: 77c66d64e7d1a8b458934029d50fcbf1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4982128866427547142, guid: 77c66d64e7d1a8b458934029d50fcbf1, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 77c66d64e7d1a8b458934029d50fcbf1, type: 3}
---- !u!4 &7309651607474143062 stripped
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &6985043431180457887
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3337440325306026196}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300048, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: -0.0001642108, y: -0.072054684, z: 0.4943595}
+    m_Extent: {x: 0.72779393, y: 0.6037213, z: 0.56695795}
+  m_DirtyAABB: 0
+--- !u!1 &3445716968856947158
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8896689529004450494}
+  - component: {fileID: 5757475506271557348}
+  m_Layer: 0
+  m_Name: Body20
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &8896689529004450494
 Transform:
-  m_CorrespondingSourceObject: {fileID: 4982128866425777382, guid: 77c66d64e7d1a8b458934029d50fcbf1, type: 3}
-  m_PrefabInstance: {fileID: 2329780090782405552}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &2712085405823715523
-PrefabInstance:
   m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3445716968856947158}
   serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 2157046098051586499}
-    m_Modifications:
-    - target: {fileID: 8842376448992230921, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
-    - target: {fileID: 8842376448995045161, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
-      propertyPath: m_RootOrder
-      value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 8842376448995045161, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.22065039
-      objectReference: {fileID: 0}
-    - target: {fileID: 8842376448995045161, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.02834493
-      objectReference: {fileID: 0}
-    - target: {fileID: 8842376448995045161, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.15955243
-      objectReference: {fileID: 0}
-    - target: {fileID: 8842376448995045161, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.5024751
-      objectReference: {fileID: 0}
-    - target: {fileID: 8842376448995045161, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.49885765
-      objectReference: {fileID: 0}
-    - target: {fileID: 8842376448995045161, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.4993508
-      objectReference: {fileID: 0}
-    - target: {fileID: 8842376448995045161, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.49930817
-      objectReference: {fileID: 0}
-    - target: {fileID: 8842376448995045161, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8842376448995045161, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8842376448995045161, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8842376448995406601, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
-      propertyPath: m_Name
-      value: ElectricGunDefault
-      objectReference: {fileID: 0}
-    - target: {fileID: 8842376448995406601, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
---- !u!4 &6851432739259148266 stripped
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &5757475506271557348
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3445716968856947158}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300078, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: 0.0074983686, y: -0.12014857, z: 0.4533637}
+    m_Extent: {x: 0.5060537, y: 0.5879432, z: 0.5344309}
+  m_DirtyAABB: 0
+--- !u!1 &3499370228710893674
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6033035017459168276}
+  - component: {fileID: 9156603284253232412}
+  - component: {fileID: 5015569251591370970}
+  m_Layer: 7
+  m_Name: Player
+  m_TagString: Player
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6033035017459168276
 Transform:
-  m_CorrespondingSourceObject: {fileID: 8842376448995045161, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
-  m_PrefabInstance: {fileID: 2712085405823715523}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &3222313135784317127
-PrefabInstance:
   m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3499370228710893674}
   serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 2157046098051586499}
-    m_Modifications:
-    - target: {fileID: 2797637213908180465, guid: ca77f62d2888f6c4a874efb77151ed72, type: 3}
-      propertyPath: m_RootOrder
-      value: 15
-      objectReference: {fileID: 0}
-    - target: {fileID: 2797637213908180465, guid: ca77f62d2888f6c4a874efb77151ed72, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.109
-      objectReference: {fileID: 0}
-    - target: {fileID: 2797637213908180465, guid: ca77f62d2888f6c4a874efb77151ed72, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.026
-      objectReference: {fileID: 0}
-    - target: {fileID: 2797637213908180465, guid: ca77f62d2888f6c4a874efb77151ed72, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.142
-      objectReference: {fileID: 0}
-    - target: {fileID: 2797637213908180465, guid: ca77f62d2888f6c4a874efb77151ed72, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.5024751
-      objectReference: {fileID: 0}
-    - target: {fileID: 2797637213908180465, guid: ca77f62d2888f6c4a874efb77151ed72, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.49885765
-      objectReference: {fileID: 0}
-    - target: {fileID: 2797637213908180465, guid: ca77f62d2888f6c4a874efb77151ed72, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.4993508
-      objectReference: {fileID: 0}
-    - target: {fileID: 2797637213908180465, guid: ca77f62d2888f6c4a874efb77151ed72, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.49930817
-      objectReference: {fileID: 0}
-    - target: {fileID: 2797637213908180465, guid: ca77f62d2888f6c4a874efb77151ed72, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2797637213908180465, guid: ca77f62d2888f6c4a874efb77151ed72, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2797637213908180465, guid: ca77f62d2888f6c4a874efb77151ed72, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2797637213908533713, guid: ca77f62d2888f6c4a874efb77151ed72, type: 3}
-      propertyPath: m_Name
-      value: CrossBowDefault
-      objectReference: {fileID: 0}
-    - target: {fileID: 2797637213908533713, guid: ca77f62d2888f6c4a874efb77151ed72, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2797637213913746641, guid: ca77f62d2888f6c4a874efb77151ed72, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: ca77f62d2888f6c4a874efb77151ed72, type: 3}
---- !u!4 &748935095315254582 stripped
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 5.27, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3874544495950623930}
+  - {fileID: 4752143921221765227}
+  - {fileID: 6938851606149577591}
+  - {fileID: 2543077382266436679}
+  - {fileID: 5050466844823563696}
+  - {fileID: 7867196015830375906}
+  - {fileID: 6014408480055892977}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &9156603284253232412
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3499370228710893674}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce9b6abc9f37ae4e8741f8034296c8c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  attribute:
+    Health:
+      AttributeName: Health
+      MaxValue: 10
+      BaseValue: 0
+      CurValue: 3.59
+    Attack:
+      AttributeName: Attack
+      MaxValue: 10
+      BaseValue: 0
+      CurValue: 2.04
+    AttackSpeed:
+      AttributeName: AttackSpeed
+      MaxValue: 10
+      BaseValue: 0
+      CurValue: 1.72
+    Speed:
+      AttributeName: Speed
+      MaxValue: 10
+      BaseValue: 0
+      CurValue: 2.58
+  calcVelocity: {x: 0, y: 0, z: 0}
+  characterController: {fileID: 5015569251591370970}
+  jumpHeight: 2
+  gravity: -9.81
+  groundLayerMask:
+    serializedVersion: 2
+    m_Bits: 8
+  groundCheckDistance: 0.3
+  isDead: 0
+  animator: {fileID: 846351509328440390}
+  controller: {fileID: 3483381238265968467}
+  fxSystem: {fileID: 7517856810503511536}
+  abilitySystem: {fileID: 7283058493117225064}
+  currentWeaponEffect: {fileID: 0}
+  inputController: {fileID: 0}
+  rotationSpeed: 2
+  cameraTransform: {fileID: 0}
+  scanForTargets: {fileID: 8911144724034153150}
+  lookatCam: {fileID: 1367012689238849940}
+  gizmoColor: {r: 1, g: 0, b: 0, a: 1}
+  scanRadius: 5
+  itemLayer:
+    serializedVersion: 2
+    m_Bits: 256
+  itemdescriptionView: {fileID: 0}
+  fireCount: 1
+  fireMultypleCount: 1
+  magnetRange: 3
+  magnetPower: 1.5
+--- !u!143 &5015569251591370970
+CharacterController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3499370228710893674}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Height: 2
+  m_Radius: 0.5
+  m_SlopeLimit: 45
+  m_StepOffset: 0.3
+  m_SkinWidth: 0.0001
+  m_MinMoveDistance: 0.001
+  m_Center: {x: 0, y: 1, z: 0}
+--- !u!1 &3638041912570561979
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6780166237036356437}
+  - component: {fileID: 6472001635388903470}
+  m_Layer: 0
+  m_Name: Head01
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6780166237036356437
 Transform:
-  m_CorrespondingSourceObject: {fileID: 2797637213908180465, guid: ca77f62d2888f6c4a874efb77151ed72, type: 3}
-  m_PrefabInstance: {fileID: 3222313135784317127}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &3329337398637508514
-PrefabInstance:
   m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3638041912570561979}
   serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 2157046098051586499}
-    m_Modifications:
-    - target: {fileID: 2196376887936773799, guid: 79cfad6d28604f54a97b32d45af9d2b2, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
-    - target: {fileID: 2196376887939949475, guid: 79cfad6d28604f54a97b32d45af9d2b2, type: 3}
-      propertyPath: m_Name
-      value: MiniGunDefault
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196376887939949475, guid: 79cfad6d28604f54a97b32d45af9d2b2, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196376887940251523, guid: 79cfad6d28604f54a97b32d45af9d2b2, type: 3}
-      propertyPath: m_RootOrder
-      value: 19
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196376887940251523, guid: 79cfad6d28604f54a97b32d45af9d2b2, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.099
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196376887940251523, guid: 79cfad6d28604f54a97b32d45af9d2b2, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.237
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196376887940251523, guid: 79cfad6d28604f54a97b32d45af9d2b2, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.109
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196376887940251523, guid: 79cfad6d28604f54a97b32d45af9d2b2, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.5024751
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196376887940251523, guid: 79cfad6d28604f54a97b32d45af9d2b2, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.49885765
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196376887940251523, guid: 79cfad6d28604f54a97b32d45af9d2b2, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.4993508
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196376887940251523, guid: 79cfad6d28604f54a97b32d45af9d2b2, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.49930817
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196376887940251523, guid: 79cfad6d28604f54a97b32d45af9d2b2, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196376887940251523, guid: 79cfad6d28604f54a97b32d45af9d2b2, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196376887940251523, guid: 79cfad6d28604f54a97b32d45af9d2b2, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 79cfad6d28604f54a97b32d45af9d2b2, type: 3}
---- !u!4 &3481062188485462049 stripped
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &6472001635388903470
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3638041912570561979}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300000, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: -0.011383608, y: 0.030555248, z: 1.409427}
+    m_Extent: {x: 0.49479586, y: 0.5884634, z: 0.636757}
+  m_DirtyAABB: 0
+--- !u!1 &3710792953055973622
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6938851606149577591}
+  - component: {fileID: 7283058493117225064}
+  m_Layer: 0
+  m_Name: AbilitySystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6938851606149577591
 Transform:
-  m_CorrespondingSourceObject: {fileID: 2196376887940251523, guid: 79cfad6d28604f54a97b32d45af9d2b2, type: 3}
-  m_PrefabInstance: {fileID: 3329337398637508514}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &3636403364193470390
-PrefabInstance:
   m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3710792953055973622}
   serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 2157046098051586499}
-    m_Modifications:
-    - target: {fileID: 2440554163673562166, guid: aa9e0e616408abf4896f703b691204ed, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
-    - target: {fileID: 2440554163675463382, guid: aa9e0e616408abf4896f703b691204ed, type: 3}
-      propertyPath: m_RootOrder
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 2440554163675463382, guid: aa9e0e616408abf4896f703b691204ed, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.095
-      objectReference: {fileID: 0}
-    - target: {fileID: 2440554163675463382, guid: aa9e0e616408abf4896f703b691204ed, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.032
-      objectReference: {fileID: 0}
-    - target: {fileID: 2440554163675463382, guid: aa9e0e616408abf4896f703b691204ed, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.026
-      objectReference: {fileID: 0}
-    - target: {fileID: 2440554163675463382, guid: aa9e0e616408abf4896f703b691204ed, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.5024751
-      objectReference: {fileID: 0}
-    - target: {fileID: 2440554163675463382, guid: aa9e0e616408abf4896f703b691204ed, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.49885765
-      objectReference: {fileID: 0}
-    - target: {fileID: 2440554163675463382, guid: aa9e0e616408abf4896f703b691204ed, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.4993508
-      objectReference: {fileID: 0}
-    - target: {fileID: 2440554163675463382, guid: aa9e0e616408abf4896f703b691204ed, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.49930817
-      objectReference: {fileID: 0}
-    - target: {fileID: 2440554163675463382, guid: aa9e0e616408abf4896f703b691204ed, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2440554163675463382, guid: aa9e0e616408abf4896f703b691204ed, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2440554163675463382, guid: aa9e0e616408abf4896f703b691204ed, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2440554163675751158, guid: aa9e0e616408abf4896f703b691204ed, type: 3}
-      propertyPath: m_Name
-      value: GravityGunDefault
-      objectReference: {fileID: 0}
-    - target: {fileID: 2440554163675751158, guid: aa9e0e616408abf4896f703b691204ed, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: aa9e0e616408abf4896f703b691204ed, type: 3}
---- !u!4 &1416820251381758304 stripped
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -5.27, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1941837650190776544}
+  m_Father: {fileID: 6033035017459168276}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7283058493117225064
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3710792953055973622}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c800aec2fc7201442874e7394c8adc66, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &3837146120328556416
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8237531065322750037}
+  m_Layer: 0
+  m_Name: Target (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8237531065322750037
 Transform:
-  m_CorrespondingSourceObject: {fileID: 2440554163675463382, guid: aa9e0e616408abf4896f703b691204ed, type: 3}
-  m_PrefabInstance: {fileID: 3636403364193470390}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &3748188064020707257
-PrefabInstance:
   m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3837146120328556416}
   serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 2157046098051586499}
-    m_Modifications:
-    - target: {fileID: 7780763529669504476, guid: 61865cafb461b3b48a451dca4f88e17a, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
-    - target: {fileID: 7780763529671439132, guid: 61865cafb461b3b48a451dca4f88e17a, type: 3}
-      propertyPath: m_Name
-      value: GrenadeDefault
-      objectReference: {fileID: 0}
-    - target: {fileID: 7780763529671439132, guid: 61865cafb461b3b48a451dca4f88e17a, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7780763529671798588, guid: 61865cafb461b3b48a451dca4f88e17a, type: 3}
-      propertyPath: m_RootOrder
-      value: 21
-      objectReference: {fileID: 0}
-    - target: {fileID: 7780763529671798588, guid: 61865cafb461b3b48a451dca4f88e17a, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.141
-      objectReference: {fileID: 0}
-    - target: {fileID: 7780763529671798588, guid: 61865cafb461b3b48a451dca4f88e17a, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.088
-      objectReference: {fileID: 0}
-    - target: {fileID: 7780763529671798588, guid: 61865cafb461b3b48a451dca4f88e17a, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.009
-      objectReference: {fileID: 0}
-    - target: {fileID: 7780763529671798588, guid: 61865cafb461b3b48a451dca4f88e17a, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.5024751
-      objectReference: {fileID: 0}
-    - target: {fileID: 7780763529671798588, guid: 61865cafb461b3b48a451dca4f88e17a, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.49885765
-      objectReference: {fileID: 0}
-    - target: {fileID: 7780763529671798588, guid: 61865cafb461b3b48a451dca4f88e17a, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.4993508
-      objectReference: {fileID: 0}
-    - target: {fileID: 7780763529671798588, guid: 61865cafb461b3b48a451dca4f88e17a, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.49930817
-      objectReference: {fileID: 0}
-    - target: {fileID: 7780763529671798588, guid: 61865cafb461b3b48a451dca4f88e17a, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7780763529671798588, guid: 61865cafb461b3b48a451dca4f88e17a, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7780763529671798588, guid: 61865cafb461b3b48a451dca4f88e17a, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 61865cafb461b3b48a451dca4f88e17a, type: 3}
---- !u!4 &6917227880644008069 stripped
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 720609310541482530}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3932204134158595756
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2378788658461824038}
+  m_Layer: 0
+  m_Name: calf_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2378788658461824038
 Transform:
-  m_CorrespondingSourceObject: {fileID: 7780763529671798588, guid: 61865cafb461b3b48a451dca4f88e17a, type: 3}
-  m_PrefabInstance: {fileID: 3748188064020707257}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &4596742455878921695
-PrefabInstance:
   m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3932204134158595756}
   serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 2157046098051586499}
-    m_Modifications:
-    - target: {fileID: 2031753809481465525, guid: 1f1289a1c8e71ab4f9f8050e0a78c9ca, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
-    - target: {fileID: 2031753809493029809, guid: 1f1289a1c8e71ab4f9f8050e0a78c9ca, type: 3}
-      propertyPath: m_Name
-      value: ShotgunDefault
-      objectReference: {fileID: 0}
-    - target: {fileID: 2031753809493029809, guid: 1f1289a1c8e71ab4f9f8050e0a78c9ca, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2031753809493454737, guid: 1f1289a1c8e71ab4f9f8050e0a78c9ca, type: 3}
-      propertyPath: m_RootOrder
-      value: 17
-      objectReference: {fileID: 0}
-    - target: {fileID: 2031753809493454737, guid: 1f1289a1c8e71ab4f9f8050e0a78c9ca, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.068
-      objectReference: {fileID: 0}
-    - target: {fileID: 2031753809493454737, guid: 1f1289a1c8e71ab4f9f8050e0a78c9ca, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.053
-      objectReference: {fileID: 0}
-    - target: {fileID: 2031753809493454737, guid: 1f1289a1c8e71ab4f9f8050e0a78c9ca, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.116
-      objectReference: {fileID: 0}
-    - target: {fileID: 2031753809493454737, guid: 1f1289a1c8e71ab4f9f8050e0a78c9ca, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.5024751
-      objectReference: {fileID: 0}
-    - target: {fileID: 2031753809493454737, guid: 1f1289a1c8e71ab4f9f8050e0a78c9ca, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.49885765
-      objectReference: {fileID: 0}
-    - target: {fileID: 2031753809493454737, guid: 1f1289a1c8e71ab4f9f8050e0a78c9ca, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.4993508
-      objectReference: {fileID: 0}
-    - target: {fileID: 2031753809493454737, guid: 1f1289a1c8e71ab4f9f8050e0a78c9ca, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.49930817
-      objectReference: {fileID: 0}
-    - target: {fileID: 2031753809493454737, guid: 1f1289a1c8e71ab4f9f8050e0a78c9ca, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2031753809493454737, guid: 1f1289a1c8e71ab4f9f8050e0a78c9ca, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2031753809493454737, guid: 1f1289a1c8e71ab4f9f8050e0a78c9ca, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 1f1289a1c8e71ab4f9f8050e0a78c9ca, type: 3}
---- !u!4 &2592056586893115982 stripped
+  m_LocalRotation: {x: -0.047882114, y: -0.019919308, z: 0.1335271, w: 0.9896874}
+  m_LocalPosition: {x: -0.1545748, y: 0.0043343566, z: 0.0016697466}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4406280064483383993}
+  m_Father: {fileID: 3612848061301910226}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3946407227879573061
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7311588285887538455}
+  m_Layer: 0
+  m_Name: upperarm_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7311588285887538455
 Transform:
-  m_CorrespondingSourceObject: {fileID: 2031753809493454737, guid: 1f1289a1c8e71ab4f9f8050e0a78c9ca, type: 3}
-  m_PrefabInstance: {fileID: 4596742455878921695}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &4659452297460050564
-PrefabInstance:
   m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3946407227879573061}
   serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 6437870964944921167}
-    m_Modifications:
-    - target: {fileID: 834927088867336716, guid: 63998f5f7f6740f45a2652a1be8e3395, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 834927088867336716, guid: 63998f5f7f6740f45a2652a1be8e3395, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 834927088867336716, guid: 63998f5f7f6740f45a2652a1be8e3395, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 834927088867336716, guid: 63998f5f7f6740f45a2652a1be8e3395, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 834927088867336716, guid: 63998f5f7f6740f45a2652a1be8e3395, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 834927088867336716, guid: 63998f5f7f6740f45a2652a1be8e3395, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 834927088867336716, guid: 63998f5f7f6740f45a2652a1be8e3395, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 834927088867336716, guid: 63998f5f7f6740f45a2652a1be8e3395, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 834927088867336716, guid: 63998f5f7f6740f45a2652a1be8e3395, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 834927088867336716, guid: 63998f5f7f6740f45a2652a1be8e3395, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2251704862427300321, guid: 63998f5f7f6740f45a2652a1be8e3395, type: 3}
-      propertyPath: AbilityTag
-      value: 15
-      objectReference: {fileID: 0}
-    - target: {fileID: 2251704862427300321, guid: 63998f5f7f6740f45a2652a1be8e3395, type: 3}
-      propertyPath: Equip_state_Tag
-      value: 16
-      objectReference: {fileID: 0}
-    - target: {fileID: 7079138422186737321, guid: 63998f5f7f6740f45a2652a1be8e3395, type: 3}
-      propertyPath: m_Name
-      value: SkillAttack
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 63998f5f7f6740f45a2652a1be8e3395, type: 3}
---- !u!4 &5422319584633030792 stripped
+  m_LocalRotation: {x: 0.1359213, y: -0.4692266, z: -0.21716502, w: 0.8450984}
+  m_LocalPosition: {x: 0.10493461, y: -0.000007777511, z: 0.006657781}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5902382403927227889}
+  m_Father: {fileID: 3753088472699768561}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4015941952045471057
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6223270347521408479}
+  - component: {fileID: 5297473964047356988}
+  m_Layer: 0
+  m_Name: Head10
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &6223270347521408479
 Transform:
-  m_CorrespondingSourceObject: {fileID: 834927088867336716, guid: 63998f5f7f6740f45a2652a1be8e3395, type: 3}
-  m_PrefabInstance: {fileID: 4659452297460050564}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &5108517554561350190
-PrefabInstance:
   m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4015941952045471057}
   serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 2157046098258846160}
-    m_Modifications:
-    - target: {fileID: 3823321262689815620, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
-    - target: {fileID: 3823321262691816068, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
-      propertyPath: m_Name
-      value: Pistol_LeftDefault
-      objectReference: {fileID: 0}
-    - target: {fileID: 3823321262691816068, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
-      propertyPath: m_RootOrder
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.077
-      objectReference: {fileID: 0}
-    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.023
-      objectReference: {fileID: 0}
-    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.49885768
-      objectReference: {fileID: 0}
-    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.50247514
-      objectReference: {fileID: 0}
-    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.49930817
-      objectReference: {fileID: 0}
-    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.49935076
-      objectReference: {fileID: 0}
-    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
---- !u!4 &8352545393611895946 stripped
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &5297473964047356988
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4015941952045471057}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300018, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: -0.014941692, y: -0.051621675, z: 1.3762658}
+    m_Extent: {x: 0.68065834, y: 0.6584497, z: 0.60359573}
+  m_DirtyAABB: 0
+--- !u!1 &4084576275301460252
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6771029261450743279}
+  m_Layer: 0
+  m_Name: ring_01_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6771029261450743279
 Transform:
-  m_CorrespondingSourceObject: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
-  m_PrefabInstance: {fileID: 5108517554561350190}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &5467818339984310009
-PrefabInstance:
   m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4084576275301460252}
   serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 2157046098051586499}
-    m_Modifications:
-    - target: {fileID: 2273022344544402400, guid: 180fdca6a657c804ea236f9f0ac7d81b, type: 3}
-      propertyPath: m_RootOrder
-      value: 13
-      objectReference: {fileID: 0}
-    - target: {fileID: 2273022344544402400, guid: 180fdca6a657c804ea236f9f0ac7d81b, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.064
-      objectReference: {fileID: 0}
-    - target: {fileID: 2273022344544402400, guid: 180fdca6a657c804ea236f9f0ac7d81b, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.025
-      objectReference: {fileID: 0}
-    - target: {fileID: 2273022344544402400, guid: 180fdca6a657c804ea236f9f0ac7d81b, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.163
-      objectReference: {fileID: 0}
-    - target: {fileID: 2273022344544402400, guid: 180fdca6a657c804ea236f9f0ac7d81b, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.5024751
-      objectReference: {fileID: 0}
-    - target: {fileID: 2273022344544402400, guid: 180fdca6a657c804ea236f9f0ac7d81b, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.49885765
-      objectReference: {fileID: 0}
-    - target: {fileID: 2273022344544402400, guid: 180fdca6a657c804ea236f9f0ac7d81b, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.4993508
-      objectReference: {fileID: 0}
-    - target: {fileID: 2273022344544402400, guid: 180fdca6a657c804ea236f9f0ac7d81b, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.49930817
-      objectReference: {fileID: 0}
-    - target: {fileID: 2273022344544402400, guid: 180fdca6a657c804ea236f9f0ac7d81b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2273022344544402400, guid: 180fdca6a657c804ea236f9f0ac7d81b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2273022344544402400, guid: 180fdca6a657c804ea236f9f0ac7d81b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2273022344544888768, guid: 180fdca6a657c804ea236f9f0ac7d81b, type: 3}
-      propertyPath: m_Name
-      value: RailGunDefault
-      objectReference: {fileID: 0}
-    - target: {fileID: 2273022344544888768, guid: 180fdca6a657c804ea236f9f0ac7d81b, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2273022344556391108, guid: 180fdca6a657c804ea236f9f0ac7d81b, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 180fdca6a657c804ea236f9f0ac7d81b, type: 3}
---- !u!4 &6082940367156102425 stripped
+  m_LocalRotation: {x: -0.052653857, y: 0.0042588566, z: -0.80677736, w: 0.5884894}
+  m_LocalPosition: {x: -0.12707222, y: -0.012645725, z: 0.04131098}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2012315593512496057}
+  m_Father: {fileID: 5575222440375443504}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4106213108422352801
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 101793195980115989}
+  m_Layer: 0
+  m_Name: Target (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &101793195980115989
 Transform:
-  m_CorrespondingSourceObject: {fileID: 2273022344544402400, guid: 180fdca6a657c804ea236f9f0ac7d81b, type: 3}
-  m_PrefabInstance: {fileID: 5467818339984310009}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &5774055153932252530
-PrefabInstance:
   m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4106213108422352801}
   serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 2157046098051586499}
-    m_Modifications:
-    - target: {fileID: 3323609523919431078, guid: d4481c76bd8df8844b540671759a53e0, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
-    - target: {fileID: 3323609523921369958, guid: d4481c76bd8df8844b540671759a53e0, type: 3}
-      propertyPath: m_Name
-      value: SniperRifleDefault
-      objectReference: {fileID: 0}
-    - target: {fileID: 3323609523921369958, guid: d4481c76bd8df8844b540671759a53e0, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3323609523921856326, guid: d4481c76bd8df8844b540671759a53e0, type: 3}
-      propertyPath: m_RootOrder
-      value: 12
-      objectReference: {fileID: 0}
-    - target: {fileID: 3323609523921856326, guid: d4481c76bd8df8844b540671759a53e0, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.039
-      objectReference: {fileID: 0}
-    - target: {fileID: 3323609523921856326, guid: d4481c76bd8df8844b540671759a53e0, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.018
-      objectReference: {fileID: 0}
-    - target: {fileID: 3323609523921856326, guid: d4481c76bd8df8844b540671759a53e0, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.006
-      objectReference: {fileID: 0}
-    - target: {fileID: 3323609523921856326, guid: d4481c76bd8df8844b540671759a53e0, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.5024751
-      objectReference: {fileID: 0}
-    - target: {fileID: 3323609523921856326, guid: d4481c76bd8df8844b540671759a53e0, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.49885765
-      objectReference: {fileID: 0}
-    - target: {fileID: 3323609523921856326, guid: d4481c76bd8df8844b540671759a53e0, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.4993508
-      objectReference: {fileID: 0}
-    - target: {fileID: 3323609523921856326, guid: d4481c76bd8df8844b540671759a53e0, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.49930817
-      objectReference: {fileID: 0}
-    - target: {fileID: 3323609523921856326, guid: d4481c76bd8df8844b540671759a53e0, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3323609523921856326, guid: d4481c76bd8df8844b540671759a53e0, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3323609523921856326, guid: d4481c76bd8df8844b540671759a53e0, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: d4481c76bd8df8844b540671759a53e0, type: 3}
---- !u!4 &9096785062607884852 stripped
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5299052495832415554}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4135263100120177198
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7665874836197964155}
+  - component: {fileID: 7660979141910070398}
+  m_Layer: 0
+  m_Name: Body13
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &7665874836197964155
 Transform:
-  m_CorrespondingSourceObject: {fileID: 3323609523921856326, guid: d4481c76bd8df8844b540671759a53e0, type: 3}
-  m_PrefabInstance: {fileID: 5774055153932252530}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &6334470283676821859
+  m_GameObject: {fileID: 4135263100120177198}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &7660979141910070398
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4135263100120177198}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300064, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: -0.0009431541, y: -0.08320141, z: 0.4614281}
+    m_Extent: {x: 0.54177165, y: 0.60521185, z: 0.52980155}
+  m_DirtyAABB: 0
+--- !u!1 &4177380387247795780
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2850555212391482384}
+  - component: {fileID: 3348854079185086991}
+  m_Layer: 0
+  m_Name: Rig 3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2850555212391482384
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4177380387247795780}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -5.27, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 9020029325738588377}
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3348854079185086991
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4177380387247795780}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 70b342d8ce5c2fd48b8fa3147d48d1d1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 0
+  m_Effectors: []
+--- !u!1 &4251482128501524258
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3636697070676811153}
+  - component: {fileID: 306215955300342331}
+  m_Layer: 0
+  m_Name: Body10
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &3636697070676811153
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4251482128501524258}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &306215955300342331
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4251482128501524258}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300058, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: 0.004420042, y: -0.09150994, z: 0.44983375}
+    m_Extent: {x: 0.5335111, y: 0.59556806, z: 0.52824426}
+  m_DirtyAABB: 0
+--- !u!1 &4274362000619634153
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3839839691000887865}
+  - component: {fileID: 9171426240501377702}
+  m_Layer: 0
+  m_Name: Head09
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &3839839691000887865
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4274362000619634153}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &9171426240501377702
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4274362000619634153}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300016, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: -0.011919826, y: -0.22076762, z: 1.3220799}
+    m_Extent: {x: 0.46057934, y: 0.59116954, z: 0.54941}
+  m_DirtyAABB: 0
+--- !u!1 &4294753706530094571
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 705103427817208690}
+  m_Layer: 0
+  m_Name: head
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &705103427817208690
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4294753706530094571}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.18628515, y: -0.017911617, z: -0.09401923, w: 0.9778228}
+  m_LocalPosition: {x: -0.27939242, y: 0.038948957, z: -0.0059307474}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1848859554969393590}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4540412884746074837
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5050466844823563696}
+  - component: {fileID: 1367012689238849940}
+  - component: {fileID: 2380415323229860771}
+  - component: {fileID: 719446145401446407}
+  m_Layer: 0
+  m_Name: LookAtCam
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5050466844823563696
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4540412884746074837}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.4690681, y: -0.3359602, z: 0.19893257, w: 0.79216903}
+  m_LocalPosition: {x: 2.72, y: 2.25, z: -2.63}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6033035017459168276}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1367012689238849940
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4540412884746074837}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f9dfa5b682dcd46bda6128250e975f58, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Priority:
+    Enabled: 1
+    m_Value: 0
+  OutputChannel: 1
+  StandbyUpdate: 2
+  m_StreamingVersion: 20241001
+  m_LegacyPriority: 0
+  Target:
+    TrackingTarget: {fileID: 7867196015830375906}
+    LookAtTarget: {fileID: 0}
+    CustomLookAtTarget: 0
+  Lens:
+    FieldOfView: 60.000004
+    OrthographicSize: 10
+    NearClipPlane: 0.1
+    FarClipPlane: 5000
+    Dutch: 0
+    ModeOverride: 0
+    PhysicalProperties:
+      GateFit: 2
+      SensorSize: {x: 21.946, y: 16.002}
+      LensShift: {x: 0, y: 0}
+      FocusDistance: 10
+      Iso: 200
+      ShutterSpeed: 0.005
+      Aperture: 16
+      BladeCount: 5
+      Curvature: {x: 2, y: 11}
+      BarrelClipping: 0.25
+      Anamorphism: 0
+  BlendHint: 0
+--- !u!114 &2380415323229860771
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4540412884746074837}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f38bda98361e1de48a4ca2bd86ea3c17, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Composition:
+    ScreenPosition: {x: 0, y: 0}
+    DeadZone:
+      Enabled: 0
+      Size: {x: 0.2, y: 0.2}
+    HardLimits:
+      Enabled: 0
+      Size: {x: 0.8, y: 0.8}
+      Offset: {x: 0, y: 0}
+  CenterOnActivate: 1
+  TargetOffset: {x: 0, y: 0.62, z: 0}
+  Damping: {x: 0.5, y: 0.5}
+  Lookahead:
+    Enabled: 0
+    Time: 0
+    Smoothing: 0
+    IgnoreY: 0
+--- !u!114 &719446145401446407
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4540412884746074837}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4eb4843bae7d24943842ea23130dcd55, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  FramingMode: 2
+  FramingSize: 0.8
+  CenterOffset: {x: 0, y: 0}
+  Damping: 2
+  SizeAdjustment: 2
+  LateralAdjustment: 0
+  FovRange: {x: 1, y: 100}
+  DollyRange: {x: -100, y: 100}
+  OrthoSizeRange: {x: 1, y: 1000}
+--- !u!1 &4906058026721346797
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3747024015267831885}
+  - component: {fileID: 2924140492264821467}
+  m_Layer: 0
+  m_Name: Body06
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &3747024015267831885
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4906058026721346797}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &2924140492264821467
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4906058026721346797}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300050, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: -0.018616438, y: 0.04596275, z: 0.48210913}
+    m_Extent: {x: 0.6623423, y: 0.7539962, z: 0.5807361}
+  m_DirtyAABB: 0
+--- !u!1 &4944814007702728075
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1354554976911609914}
+  - component: {fileID: 1962435625424035156}
+  m_Layer: 0
+  m_Name: Body09
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1354554976911609914
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4944814007702728075}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &1962435625424035156
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4944814007702728075}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300056, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: -0.01132071, y: -0.10165703, z: 0.47638214}
+    m_Extent: {x: 0.69745475, y: 0.60627747, z: 0.543936}
+  m_DirtyAABB: 0
+--- !u!1 &4995774084705897916
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8492314803017277401}
+  m_Layer: 0
+  m_Name: root
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8492314803017277401
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4995774084705897916}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4205418828267842209}
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5053299420551502413
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2604113929739101319}
+  - component: {fileID: 2969890931985281480}
+  m_Layer: 0
+  m_Name: Body07
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &2604113929739101319
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5053299420551502413}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &2969890931985281480
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5053299420551502413}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300052, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: -0.014973938, y: -0.059782505, z: 0.4601206}
+    m_Extent: {x: 0.68371534, y: 0.6384994, z: 0.54447854}
+  m_DirtyAABB: 0
+--- !u!1 &5076840329801328447
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 204207914782224781}
+  - component: {fileID: 6811552558903852166}
+  m_Layer: 0
+  m_Name: Head08
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &204207914782224781
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5076840329801328447}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &6811552558903852166
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5076840329801328447}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300014, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: -0.0062411427, y: -0.013890296, z: 1.2690101}
+    m_Extent: {x: 0.41955596, y: 0.4166621, z: 0.49634004}
+  m_DirtyAABB: 0
+--- !u!1 &5171188143731272965
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8003368973500978536}
+  m_Layer: 0
+  m_Name: ball_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8003368973500978536
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5171188143731272965}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.0030611525, y: -0.008212709, z: 0.7100026, w: 0.70414454}
+  m_LocalPosition: {x: 0.020676011, y: -0.17323646, z: 0.00075461436}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 518966291794105451}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5355718062219726664
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3874544495950623930}
+  - component: {fileID: 846351509328440390}
+  - component: {fileID: 3483381238265968467}
+  - component: {fileID: 3573739957340906215}
+  - component: {fileID: 1087073890245104047}
+  m_Layer: 0
+  m_Name: PlayerModel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3874544495950623930
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5355718062219726664}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4342469588772820763}
+  - {fileID: 5659159893204350733}
+  - {fileID: 1695844588078778786}
+  - {fileID: 1538587900740975912}
+  - {fileID: 3981016198049755183}
+  - {fileID: 3747024015267831885}
+  - {fileID: 2604113929739101319}
+  - {fileID: 8080612197796514438}
+  - {fileID: 1354554976911609914}
+  - {fileID: 3636697070676811153}
+  - {fileID: 7305884043309961793}
+  - {fileID: 6453578966021127797}
+  - {fileID: 7665874836197964155}
+  - {fileID: 944120460418931879}
+  - {fileID: 8992972022723078433}
+  - {fileID: 7625077518370407096}
+  - {fileID: 6044424091131563869}
+  - {fileID: 9018921666353916023}
+  - {fileID: 913951962055070540}
+  - {fileID: 8896689529004450494}
+  - {fileID: 6780166237036356437}
+  - {fileID: 8349520580120789455}
+  - {fileID: 5078759826147082710}
+  - {fileID: 3309545833110839342}
+  - {fileID: 9180515192763643567}
+  - {fileID: 2877428044612164834}
+  - {fileID: 2056985541906827850}
+  - {fileID: 204207914782224781}
+  - {fileID: 3839839691000887865}
+  - {fileID: 6223270347521408479}
+  - {fileID: 6542431971311456743}
+  - {fileID: 4000473531145385761}
+  - {fileID: 5834459224378262076}
+  - {fileID: 1794062792503038935}
+  - {fileID: 5102406346611070827}
+  - {fileID: 867491537974610657}
+  - {fileID: 1935339280540536386}
+  - {fileID: 1414832981805400041}
+  - {fileID: 3321515076464057684}
+  - {fileID: 1190366250924176780}
+  - {fileID: 8492314803017277401}
+  - {fileID: 6524410901166697274}
+  - {fileID: 8518602567768092522}
+  - {fileID: 2850555212391482384}
+  - {fileID: 7524939866931432794}
+  - {fileID: 5201649495285787456}
+  m_Father: {fileID: 6033035017459168276}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!95 &846351509328440390
+Animator:
+  serializedVersion: 7
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5355718062219726664}
+  m_Enabled: 1
+  m_Avatar: {fileID: 9000000, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Controller: {fileID: 9100000, guid: ddd667bde1791624b934575b2f8b545c, type: 2}
+  m_CullingMode: 1
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!114 &3483381238265968467
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5355718062219726664}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 93005e4cac64995478b011a4506c7e69, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_heads:
+  - {fileID: 3638041912570561979}
+  - {fileID: 2163547915057320771}
+  - {fileID: 7101722475187744977}
+  - {fileID: 9089997623993568654}
+  - {fileID: 5907773872414427208}
+  - {fileID: 1410392239603405079}
+  - {fileID: 3214068859459886628}
+  - {fileID: 5076840329801328447}
+  - {fileID: 4274362000619634153}
+  - {fileID: 4015941952045471057}
+  - {fileID: 8428438694291164626}
+  - {fileID: 311006057720701336}
+  - {fileID: 6601497071983997489}
+  - {fileID: 8538575014073479405}
+  - {fileID: 7746046085241839692}
+  - {fileID: 1580391421228595334}
+  - {fileID: 7842855438559658318}
+  - {fileID: 2191322474398196031}
+  - {fileID: 115406460377357693}
+  - {fileID: 8771720668270239527}
+  m_bodys:
+  - {fileID: 7065899589908656897}
+  - {fileID: 8392297761289550467}
+  - {fileID: 990277058234112089}
+  - {fileID: 1223214939894188389}
+  - {fileID: 3337440325306026196}
+  - {fileID: 4906058026721346797}
+  - {fileID: 5053299420551502413}
+  - {fileID: 9180235951046387266}
+  - {fileID: 4944814007702728075}
+  - {fileID: 4251482128501524258}
+  - {fileID: 798549006262798705}
+  - {fileID: 5620731407719774132}
+  - {fileID: 4135263100120177198}
+  - {fileID: 6801559266755125259}
+  - {fileID: 2999059805045504880}
+  - {fileID: 9212426443394209201}
+  - {fileID: 6305595760806620517}
+  - {fileID: 1372882942246494168}
+  - {fileID: 3027464646441711849}
+  - {fileID: 3445716968856947158}
+  m_weapons:
+  - {fileID: 5350770602380368759}
+  - {fileID: 4657690215199160261}
+  - {fileID: 8197751098420373358}
+  character: {fileID: 9156603284253232412}
+  HeadAnim: {fileID: 4531949249098796545}
+  HandRighAnim: {fileID: 3329503292816657798}
+  HandLeftAnim: {fileID: 3348854079185086991}
+  LowerarmLeftAnim: {fileID: 1940242716080151451}
+  LowerarmRightAnim: {fileID: 9155258664764592767}
+  posxxx:
+    transform: {fileID: 0}
+    weight: 0
+--- !u!114 &3573739957340906215
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5355718062219726664}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fff0960ef4ea6e04eac66b4a7fd2189d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RigLayers:
+  - m_Rig: {fileID: 4531949249098796545}
+    m_Active: 1
+  - m_Rig: {fileID: 3329503292816657798}
+    m_Active: 1
+  - m_Rig: {fileID: 3348854079185086991}
+    m_Active: 1
+  - m_Rig: {fileID: 1940242716080151451}
+    m_Active: 1
+  - m_Rig: {fileID: 9155258664764592767}
+    m_Active: 1
+  m_Effectors: []
+--- !u!114 &1087073890245104047
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5355718062219726664}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b2d8418b0b9634b1892b0268dd9c2743, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  boneShape: 1
+  drawBones: 1
+  drawTripods: 0
+  boneSize: 1
+  tripodSize: 1
+  boneColor: {r: 0, g: 0, b: 1, a: 0.5}
+  m_Transforms:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 4523454433111889778}
+  - {fileID: 3753088472699768561}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 3414432838674233775}
+  - {fileID: 6771029261450743279}
+  - {fileID: 4432144893256309992}
+  - {fileID: 5405964017335039176}
+  - {fileID: 1366351487435151559}
+  - {fileID: 5630929016078573662}
+  - {fileID: 8504020186838503111}
+  - {fileID: 7116627694780175486}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 5224943072361654219}
+  - {fileID: 3387684809064655610}
+  - {fileID: 3052105946573604569}
+  - {fileID: 8900103294415453088}
+  - {fileID: 3573034330721327784}
+  - {fileID: 4025809624005013340}
+  - {fileID: 8055491384726266018}
+  - {fileID: 5945925456739147809}
+  - {fileID: 4359969340327032605}
+  - {fileID: 5763873439529026641}
+  - {fileID: 1442268046960415370}
+  - {fileID: 3378025785827044426}
+  - {fileID: 5593086463911742945}
+  - {fileID: 1538626775247677604}
+  - {fileID: 1456060276796824135}
+  - {fileID: 4704993034591711408}
+  - {fileID: 5010898995420870771}
+  - {fileID: 8586943698034465929}
+  - {fileID: 2369893309570142590}
+  - {fileID: 7489367807632813801}
+  - {fileID: 8103956736058946289}
+  - {fileID: 2956900738392463027}
+  - {fileID: 1729360963346990093}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+--- !u!1 &5359853602778543603
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4752143921221765227}
+  m_Layer: 7
+  m_Name: root
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4752143921221765227
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5359853602778543603}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.99, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6033035017459168276}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5596195360466838640
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8146382468678208126}
+  m_Layer: 0
+  m_Name: index_02_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8146382468678208126
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5596195360466838640}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.022786943, y: 0.002945359, z: -0.40929776, w: 0.9121115}
+  m_LocalPosition: {x: -0.08471742, y: -0.011332375, z: -0.0045711263}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8242313990430915567}
+  m_Father: {fileID: 3414432838674233775}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5620731407719774132
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6453578966021127797}
+  - component: {fileID: 5700506307022811912}
+  m_Layer: 0
+  m_Name: Body12
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &6453578966021127797
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5620731407719774132}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &5700506307022811912
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5620731407719774132}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300062, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: -0.0014484227, y: -0.10346103, z: 0.46982288}
+    m_Extent: {x: 0.5383637, y: 0.60449076, z: 0.5381963}
+  m_DirtyAABB: 0
+--- !u!1 &5622281755858839810
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4406280064483383993}
+  m_Layer: 0
+  m_Name: foot_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4406280064483383993
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5622281755858839810}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.1267479, y: -0.07679969, z: -0.13532273, w: 0.9796553}
+  m_LocalPosition: {x: -0.13463134, y: -0.012334914, z: -0.00009856112}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 9190791334639563356}
+  m_Father: {fileID: 2378788658461824038}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5826244526372775006
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 518966291794105451}
+  m_Layer: 0
+  m_Name: foot_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &518966291794105451
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5826244526372775006}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.11773011, y: -0.07301172, z: 0.036255144, w: 0.9896941}
+  m_LocalPosition: {x: 0.13463174, y: 0.0123348655, z: 0.00009769745}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8003368973500978536}
+  m_Father: {fileID: 6219218383762812829}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5889084064554318981
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5914098565606461513}
+  m_Layer: 0
+  m_Name: hand_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5914098565606461513
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5889084064554318981}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.79253304, y: -0.32171422, z: 0.10234816, w: 0.50785464}
+  m_LocalPosition: {x: 0.25676566, y: 0.0058458224, z: -1.508782e-10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5224943072361654219}
+  - {fileID: 3387684809064655610}
+  - {fileID: 3052105946573604569}
+  - {fileID: 8900103294415453088}
+  - {fileID: 3573034330721327784}
+  - {fileID: 4025809624005013340}
+  - {fileID: 8055491384726266018}
+  - {fileID: 5945925456739147809}
+  - {fileID: 4359969340327032605}
+  - {fileID: 5763873439529026641}
+  - {fileID: 1442268046960415370}
+  - {fileID: 3378025785827044426}
+  - {fileID: 5593086463911742945}
+  - {fileID: 1538626775247677604}
+  - {fileID: 1456060276796824135}
+  - {fileID: 4704993034591711408}
+  - {fileID: 5010898995420870771}
+  - {fileID: 8586943698034465929}
+  - {fileID: 2369893309570142590}
+  - {fileID: 7489367807632813801}
+  - {fileID: 8103956736058946289}
+  - {fileID: 2956900738392463027}
+  - {fileID: 1729360963346990093}
+  m_Father: {fileID: 5902382403927227889}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5907773872414427208
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9180515192763643567}
+  - component: {fileID: 6017063876705185607}
+  m_Layer: 0
+  m_Name: Head05
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &9180515192763643567
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5907773872414427208}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &6017063876705185607
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5907773872414427208}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300008, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: -0.014683127, y: -0.04074712, z: 1.2441804}
+    m_Extent: {x: 0.5285003, y: 0.5166766, z: 0.5127573}
+  m_DirtyAABB: 0
+--- !u!1 &5963406775106967794
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5575222440375443504}
+  m_Layer: 0
+  m_Name: hand_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5575222440375443504
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5963406775106967794}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.87721777, y: 0.100944154, z: -0.25952908, w: -0.39108044}
+  m_LocalPosition: {x: -0.25676548, y: -0.005845819, z: -2.842171e-16}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3414432838674233775}
+  - {fileID: 6771029261450743279}
+  - {fileID: 4432144893256309992}
+  - {fileID: 5405964017335039176}
+  - {fileID: 1366351487435151559}
+  - {fileID: 5630929016078573662}
+  - {fileID: 8504020186838503111}
+  - {fileID: 7116627694780175486}
+  m_Father: {fileID: 5060711278442035981}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6009802413211332105
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4205418828267842209}
+  m_Layer: 0
+  m_Name: pelvis
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4205418828267842209
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6009802413211332105}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.08801344, y: 0.7016079, z: 0.08801344, w: 0.7016079}
+  m_LocalPosition: {x: -1.0845211e-17, y: 0.01821081, z: 0.33987784}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5399429416690821740}
+  - {fileID: 3212172166270237851}
+  - {fileID: 3612848061301910226}
+  m_Father: {fileID: 8492314803017277401}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6200286276773182854
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4163629243762040412}
+  m_Layer: 0
+  m_Name: Target (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4163629243762040412
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6200286276773182854}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.44, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4854119414348150365}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6305595760806620517
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6044424091131563869}
+  - component: {fileID: 9197217703867265809}
+  m_Layer: 0
+  m_Name: Body17
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &6044424091131563869
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6305595760806620517}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &9197217703867265809
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6305595760806620517}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300072, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: 0.0076747537, y: -0.07708451, z: 0.4484692}
+    m_Extent: {x: 0.52641165, y: 0.63099086, z: 0.5263983}
+  m_DirtyAABB: 0
+--- !u!1 &6456107875088579866
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5060711278442035981}
+  m_Layer: 0
+  m_Name: lowerarm_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5060711278442035981
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6456107875088579866}
+  serializedVersion: 2
+  m_LocalRotation: {x: 2.1734088e-15, y: -9.992447e-15, z: 0.21362603, w: 0.97691554}
+  m_LocalPosition: {x: -0.21657251, y: 0.011759994, z: 4.2632563e-16}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5575222440375443504}
+  m_Father: {fileID: 8887427830417507289}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6484206252775397076
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2543077382266436679}
+  - component: {fileID: 8911144724034153150}
+  m_Layer: 7
+  m_Name: Monster Scan
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2543077382266436679
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6484206252775397076}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6033035017459168276}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8911144724034153150
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6484206252775397076}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 22487aea474137f48be4059e2cecdfbf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_TargetGroup: {fileID: 4093018836196573752}
+--- !u!1 &6565635953960626252
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8887081984817386572}
+  m_Layer: 0
+  m_Name: index_03_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8887081984817386572
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6565635953960626252}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.019108133, y: -0.021374207, z: 0.0004085892, w: 0.99958885}
+  m_LocalPosition: {x: 0.06901601, y: 0.0042007873, z: 0.0040457235}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 9031354481043070482}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6601497071983997489
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5834459224378262076}
+  - component: {fileID: 2840297780513640366}
+  m_Layer: 0
+  m_Name: Head13
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &5834459224378262076
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6601497071983997489}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &2840297780513640366
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6601497071983997489}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300024, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: -0.0076768994, y: -0.06620464, z: 1.2751006}
+    m_Extent: {x: 0.40579715, y: 0.4243664, z: 0.50243056}
+  m_DirtyAABB: 0
+--- !u!1 &6739784766088634377
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8732938456802479290}
+  m_Layer: 0
+  m_Name: thumb_03_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8732938456802479290
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6739784766088634377}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.023968818, y: -0.023600308, z: -0.025017621, w: 0.99912095}
+  m_LocalPosition: {x: 0.061903976, y: 0.00015877343, z: -0.00014186987}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1155318496298573467}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6785865022308754995
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8598222625752667699}
+  m_Layer: 0
+  m_Name: spine_03
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8598222625752667699
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6785865022308754995}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.04316875, y: -0.006253804, z: -0.0400267, w: 0.9982461}
+  m_LocalPosition: {x: -0.1342877, y: 0.0071493695, z: 6.203883e-17}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4523454433111889778}
+  - {fileID: 3753088472699768561}
+  - {fileID: 1848859554969393590}
+  m_Father: {fileID: 5906552103748992065}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6801559266755125259
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 944120460418931879}
+  - component: {fileID: 4404615143722061173}
+  m_Layer: 0
+  m_Name: Body14
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &944120460418931879
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6801559266755125259}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &4404615143722061173
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6801559266755125259}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300066, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: 0.0059496164, y: -0.07991725, z: 0.45345753}
+    m_Extent: {x: 0.52711755, y: 0.59585094, z: 0.5294749}
+  m_DirtyAABB: 0
+--- !u!1 &6964141874484825583
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8518602567768092522}
+  - component: {fileID: 3329503292816657798}
+  m_Layer: 0
+  m_Name: Rig 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8518602567768092522
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6964141874484825583}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -5.27, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 720609310541482530}
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3329503292816657798
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6964141874484825583}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 70b342d8ce5c2fd48b8fa3147d48d1d1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 0
+  m_Effectors: []
+--- !u!1 &7065899589908656897
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4342469588772820763}
+  - component: {fileID: 8960354593330195190}
+  m_Layer: 0
+  m_Name: Body01
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4342469588772820763
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7065899589908656897}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &8960354593330195190
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7065899589908656897}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300040, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: -0.010785818, y: -0.09531519, z: 0.48286515}
+    m_Extent: {x: 0.6487969, y: 0.59313667, z: 0.56032485}
+  m_DirtyAABB: 0
+--- !u!1 &7090325978787581580
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5437207413694491365}
+  m_Layer: 0
+  m_Name: Target (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5437207413694491365
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7090325978787581580}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 9020029325738588377}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7101722475187744977
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5078759826147082710}
+  - component: {fileID: 6380971555438530474}
+  m_Layer: 0
+  m_Name: Head03
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &5078759826147082710
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7101722475187744977}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &6380971555438530474
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7101722475187744977}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300004, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: -0.0072407424, y: -0.05030465, z: 1.3460083}
+    m_Extent: {x: 0.46757722, y: 0.43353295, z: 0.57333827}
+  m_DirtyAABB: 0
+--- !u!1 &7368603163894644820
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2012315593512496057}
+  m_Layer: 0
+  m_Name: ring_02_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2012315593512496057
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7368603163894644820}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.011837206, y: 0.0082373, z: -0.68030405, w: 0.73278815}
+  m_LocalPosition: {x: -0.080956735, y: -0.015202989, z: 0.00009701045}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3563986922905317837}
+  m_Father: {fileID: 6771029261450743279}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7652364122987105761
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5299052495832415554}
+  - component: {fileID: 2572727248147628127}
+  m_Layer: 0
+  m_Name: lowerarm_lAnim
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5299052495832415554
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7652364122987105761}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 2.64, y: 5.27, z: 0.97}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 101793195980115989}
+  m_Father: {fileID: 7524939866931432794}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2572727248147628127
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7652364122987105761}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3c430f382484144e925c097c2d33cfe, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Weight: 0
+  m_Data:
+    m_ConstrainedObject: {fileID: 5060711278442035981}
+    m_SourceObjects:
+      m_Length: 1
+      m_Item0:
+        transform: {fileID: 101793195980115989}
+        weight: 1
+      m_Item1:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item2:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item3:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item4:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item5:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item6:
+        transform: {fileID: 0}
+        weight: 0
+      m_Item7:
+        transform: {fileID: 0}
+        weight: 0
+    m_Offset: {x: 0, y: 0, z: 0}
+    m_MinLimit: -66
+    m_MaxLimit: 58
+    m_AimAxis: 1
+    m_UpAxis: 3
+    m_WorldUpType: 0
+    m_WorldUpObject: {fileID: 0}
+    m_WorldUpAxis: 2
+    m_MaintainOffset: 0
+    m_ConstrainedAxes:
+      x: 1
+      y: 1
+      z: 1
+--- !u!1 &7746046085241839692
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5102406346611070827}
+  - component: {fileID: 5567204064355172413}
+  m_Layer: 0
+  m_Name: Head15
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &5102406346611070827
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7746046085241839692}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 1.429432, z: -1.3900039}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &5567204064355172413
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7746046085241839692}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300028, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: -0.006421268, y: -0.020459592, z: 1.3793222}
+    m_Extent: {x: 0.41744748, y: 0.5455019, z: 0.60665214}
+  m_DirtyAABB: 0
+--- !u!1 &7842855438559658318
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1935339280540536386}
+  - component: {fileID: 4008729137640601314}
+  m_Layer: 0
+  m_Name: Head17
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1935339280540536386
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7842855438559658318}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &4008729137640601314
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7842855438559658318}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300032, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: -0.0046901703, y: 0.04261303, z: 1.3519179}
+    m_Extent: {x: 0.5007817, y: 0.5822783, z: 0.5729898}
+  m_DirtyAABB: 0
+--- !u!1 &8329307977629279075
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9211380619938324221}
+  m_Layer: 0
+  m_Name: Target
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &9211380619938324221
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8329307977629279075}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.47, y: 0, z: -1.97}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8260887543115385056}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8392297761289550467
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5659159893204350733}
+  - component: {fileID: 3954050249094108090}
+  m_Layer: 0
+  m_Name: Body02
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &5659159893204350733
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8392297761289550467}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &3954050249094108090
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8392297761289550467}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300042, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: 0.029420018, y: -0.04755336, z: 0.4913504}
+    m_Extent: {x: 0.541489, y: 0.66053826, z: 0.55294776}
+  m_DirtyAABB: 0
+--- !u!1 &8415975737511101173
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9190791334639563356}
+  m_Layer: 0
+  m_Name: ball_r
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &9190791334639563356
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8415975737511101173}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.0030611525, y: -0.008212709, z: 0.7100026, w: 0.70414454}
+  m_LocalPosition: {x: -0.020676007, y: 0.17323625, z: -0.0007544282}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4406280064483383993}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8428438694291164626
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6542431971311456743}
+  - component: {fileID: 4301710532186204937}
+  m_Layer: 0
+  m_Name: Head11
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &6542431971311456743
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8428438694291164626}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &4301710532186204937
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8428438694291164626}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300020, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: -0.021726727, y: -0.07339668, z: 1.3876714}
+    m_Extent: {x: 0.607611, y: 0.61443245, z: 0.6150013}
+  m_DirtyAABB: 0
+--- !u!1 &8463388199935035771
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5399429416690821740}
+  m_Layer: 0
+  m_Name: spine_01
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5399429416690821740
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8463388199935035771}
+  serializedVersion: 2
+  m_LocalRotation: {x: -5.1098166e-17, y: -1.6211398e-16, z: -0.05785565, w: 0.998325}
+  m_LocalPosition: {x: -0.14127474, y: 0.0024777667, z: 2.8018493e-17}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5906552103748992065}
+  m_Father: {fileID: 4205418828267842209}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8538575014073479405
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1794062792503038935}
+  - component: {fileID: 3888826303779494880}
+  m_Layer: 0
+  m_Name: Head14
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1794062792503038935
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8538575014073479405}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &3888826303779494880
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8538575014073479405}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300026, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: -0.006088078, y: -0.008313596, z: 1.2804426}
+    m_Extent: {x: 0.5317028, y: 0.56758326, z: 0.53972924}
+  m_DirtyAABB: 0
+--- !u!1 &8771720668270239527
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1190366250924176780}
+  - component: {fileID: 4620877982835625230}
+  m_Layer: 0
+  m_Name: Head20
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1190366250924176780
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8771720668270239527}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 1.3442874, z: -1.3397256}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &4620877982835625230
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8771720668270239527}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300038, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: -0.0059431493, y: -0.0030331314, z: 1.3116107}
+    m_Extent: {x: 0.47497422, y: 0.49498135, z: 0.5389408}
+  m_DirtyAABB: 0
+--- !u!1 &8977472075611295080
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4033362781427830493}
+  m_Layer: 0
+  m_Name: thumb_03_l
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4033362781427830493
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8977472075611295080}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.023968818, y: -0.023600308, z: -0.025017621, w: 0.99912095}
+  m_LocalPosition: {x: -0.06190364, y: -0.0001583865, z: 0.00014239138}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2600130595795185846}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &9059840000570670661
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7867196015830375906}
+  - component: {fileID: 4093018836196573752}
+  m_Layer: 0
+  m_Name: lockOnCam Group
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7867196015830375906
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9059840000570670661}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -5.27, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6033035017459168276}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4093018836196573752
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9059840000570670661}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e5eb80d8e62d9d145bb50fb783c0f731, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  PositionMode: 0
+  RotationMode: 0
+  UpdateMethod: 2
+  Targets: []
+  m_LegacyTargets: []
+--- !u!1 &9089997623993568654
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3309545833110839342}
+  - component: {fileID: 5322712758605661125}
+  m_Layer: 0
+  m_Name: Head04
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &3309545833110839342
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9089997623993568654}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 1.4519753, z: -1.2884914}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &5322712758605661125
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9089997623993568654}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 00eb1ba92a205e143944fa63388db963, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300006, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: -0.008140445, y: -0.08308093, z: 1.3461982}
+    m_Extent: {x: 0.57529426, y: 0.55149704, z: 0.53545773}
+  m_DirtyAABB: 0
+--- !u!1 &9180235951046387266
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8080612197796514438}
+  - component: {fileID: 7712977653613247130}
+  m_Layer: 0
+  m_Name: Body08
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &8080612197796514438
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9180235951046387266}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &7712977653613247130
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9180235951046387266}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300054, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: -0.007229924, y: -0.121120885, z: 0.50351}
+    m_Extent: {x: 0.53194827, y: 0.586971, z: 0.56232953}
+  m_DirtyAABB: 0
+--- !u!1 &9212426443394209201
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7625077518370407096}
+  - component: {fileID: 3805381801540121955}
+  m_Layer: 0
+  m_Name: Body16
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &7625077518370407096
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9212426443394209201}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3874544495950623930}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &3805381801540121955
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9212426443394209201}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 9a563ffc77d94094bac866f46e58cfa5, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 4300070, guid: 9f078227c6f09b54392514bfaa25c741, type: 3}
+  m_Bones:
+  - {fileID: 8492314803017277401}
+  - {fileID: 4205418828267842209}
+  - {fileID: 5399429416690821740}
+  - {fileID: 5906552103748992065}
+  - {fileID: 8598222625752667699}
+  - {fileID: 1848859554969393590}
+  - {fileID: 705103427817208690}
+  - {fileID: 4523454433111889778}
+  - {fileID: 8887427830417507289}
+  - {fileID: 5060711278442035981}
+  - {fileID: 5575222440375443504}
+  - {fileID: 4432144893256309992}
+  - {fileID: 2600130595795185846}
+  - {fileID: 4033362781427830493}
+  - {fileID: 3414432838674233775}
+  - {fileID: 8146382468678208126}
+  - {fileID: 8242313990430915567}
+  - {fileID: 6771029261450743279}
+  - {fileID: 2012315593512496057}
+  - {fileID: 3563986922905317837}
+  - {fileID: 3753088472699768561}
+  - {fileID: 7311588285887538455}
+  - {fileID: 5902382403927227889}
+  - {fileID: 5914098565606461513}
+  - {fileID: 3052105946573604569}
+  - {fileID: 1155318496298573467}
+  - {fileID: 8732938456802479290}
+  - {fileID: 5224943072361654219}
+  - {fileID: 9031354481043070482}
+  - {fileID: 8887081984817386572}
+  - {fileID: 3387684809064655610}
+  - {fileID: 1218629467550353174}
+  - {fileID: 4818627931214187240}
+  - {fileID: 3212172166270237851}
+  - {fileID: 6219218383762812829}
+  - {fileID: 518966291794105451}
+  - {fileID: 8003368973500978536}
+  - {fileID: 3612848061301910226}
+  - {fileID: 2378788658461824038}
+  - {fileID: 4406280064483383993}
+  - {fileID: 9190791334639563356}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 8492314803017277401}
+  m_AABB:
+    m_Center: {x: 0.0043288767, y: -0.117221326, z: 0.5234725}
+    m_Extent: {x: 0.5103134, y: 0.590711, z: 0.6049771}
+  m_DirtyAABB: 0
+--- !u!1001 &91636358761938837
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 2157046098051586499}
+    m_TransformParent: {fileID: 5914098565606461513}
     m_Modifications:
     - target: {fileID: 1545150094688118226, guid: 706c97aa8d177e1449c87cb36a81056d, type: 3}
       propertyPath: m_RootOrder
@@ -9025,18 +8194,461 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 706c97aa8d177e1449c87cb36a81056d, type: 3}
---- !u!4 &4799138432823119025 stripped
+--- !u!4 &1456060276796824135 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1545150094688118226, guid: 706c97aa8d177e1449c87cb36a81056d, type: 3}
-  m_PrefabInstance: {fileID: 6334470283676821859}
+  m_PrefabInstance: {fileID: 91636358761938837}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &6516258866946159480
+--- !u!1001 &779449436141179716
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 2157046098051586499}
+    m_TransformParent: {fileID: 5914098565606461513}
+    m_Modifications:
+    - target: {fileID: 2273022344544402400, guid: 180fdca6a657c804ea236f9f0ac7d81b, type: 3}
+      propertyPath: m_RootOrder
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 2273022344544402400, guid: 180fdca6a657c804ea236f9f0ac7d81b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.064
+      objectReference: {fileID: 0}
+    - target: {fileID: 2273022344544402400, guid: 180fdca6a657c804ea236f9f0ac7d81b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.025
+      objectReference: {fileID: 0}
+    - target: {fileID: 2273022344544402400, guid: 180fdca6a657c804ea236f9f0ac7d81b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.163
+      objectReference: {fileID: 0}
+    - target: {fileID: 2273022344544402400, guid: 180fdca6a657c804ea236f9f0ac7d81b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.5024751
+      objectReference: {fileID: 0}
+    - target: {fileID: 2273022344544402400, guid: 180fdca6a657c804ea236f9f0ac7d81b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.49885765
+      objectReference: {fileID: 0}
+    - target: {fileID: 2273022344544402400, guid: 180fdca6a657c804ea236f9f0ac7d81b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.4993508
+      objectReference: {fileID: 0}
+    - target: {fileID: 2273022344544402400, guid: 180fdca6a657c804ea236f9f0ac7d81b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.49930817
+      objectReference: {fileID: 0}
+    - target: {fileID: 2273022344544402400, guid: 180fdca6a657c804ea236f9f0ac7d81b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2273022344544402400, guid: 180fdca6a657c804ea236f9f0ac7d81b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2273022344544402400, guid: 180fdca6a657c804ea236f9f0ac7d81b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2273022344544888768, guid: 180fdca6a657c804ea236f9f0ac7d81b, type: 3}
+      propertyPath: m_Name
+      value: RailGunDefault
+      objectReference: {fileID: 0}
+    - target: {fileID: 2273022344544888768, guid: 180fdca6a657c804ea236f9f0ac7d81b, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2273022344556391108, guid: 180fdca6a657c804ea236f9f0ac7d81b, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 180fdca6a657c804ea236f9f0ac7d81b, type: 3}
+--- !u!4 &1538626775247677604 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2273022344544402400, guid: 180fdca6a657c804ea236f9f0ac7d81b, type: 3}
+  m_PrefabInstance: {fileID: 779449436141179716}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &862205620644612194
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5575222440375443504}
+    m_Modifications:
+    - target: {fileID: 1801837882128536133, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
+    - target: {fileID: 1801837882130305189, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 1801837882130305189, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.093
+      objectReference: {fileID: 0}
+    - target: {fileID: 1801837882130305189, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.017
+      objectReference: {fileID: 0}
+    - target: {fileID: 1801837882130305189, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.019
+      objectReference: {fileID: 0}
+    - target: {fileID: 1801837882130305189, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.4988578
+      objectReference: {fileID: 0}
+    - target: {fileID: 1801837882130305189, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.50247514
+      objectReference: {fileID: 0}
+    - target: {fileID: 1801837882130305189, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.4993081
+      objectReference: {fileID: 0}
+    - target: {fileID: 1801837882130305189, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.49935076
+      objectReference: {fileID: 0}
+    - target: {fileID: 1801837882130305189, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1801837882130305189, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1801837882130305189, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1801837882130795653, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
+      propertyPath: m_Name
+      value: HMG_LeftDefault
+      objectReference: {fileID: 0}
+    - target: {fileID: 1801837882130795653, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
+--- !u!4 &1366351487435151559 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1801837882130305189, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
+  m_PrefabInstance: {fileID: 862205620644612194}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1182776526615740313
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5914098565606461513}
+    m_Modifications:
+    - target: {fileID: 7775909171457901625, guid: 26c304c542935a646a21dd134e1c2cea, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.0692
+      objectReference: {fileID: 0}
+    - target: {fileID: 7775909171457901625, guid: 26c304c542935a646a21dd134e1c2cea, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.036
+      objectReference: {fileID: 0}
+    - target: {fileID: 7775909171457901625, guid: 26c304c542935a646a21dd134e1c2cea, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.014
+      objectReference: {fileID: 0}
+    - target: {fileID: 7775909171457901625, guid: 26c304c542935a646a21dd134e1c2cea, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.5024751
+      objectReference: {fileID: 0}
+    - target: {fileID: 7775909171457901625, guid: 26c304c542935a646a21dd134e1c2cea, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.49885765
+      objectReference: {fileID: 0}
+    - target: {fileID: 7775909171457901625, guid: 26c304c542935a646a21dd134e1c2cea, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.4993508
+      objectReference: {fileID: 0}
+    - target: {fileID: 7775909171457901625, guid: 26c304c542935a646a21dd134e1c2cea, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.49930817
+      objectReference: {fileID: 0}
+    - target: {fileID: 7775909171457901625, guid: 26c304c542935a646a21dd134e1c2cea, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7775909171457901625, guid: 26c304c542935a646a21dd134e1c2cea, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7775909171457901625, guid: 26c304c542935a646a21dd134e1c2cea, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7775909171458005017, guid: 26c304c542935a646a21dd134e1c2cea, type: 3}
+      propertyPath: m_Name
+      value: AssaultRifle
+      objectReference: {fileID: 0}
+    - target: {fileID: 7775909171458005017, guid: 26c304c542935a646a21dd134e1c2cea, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 26c304c542935a646a21dd134e1c2cea, type: 3}
+--- !u!114 &5350770602380368759 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6497517203303556334, guid: 26c304c542935a646a21dd134e1c2cea, type: 3}
+  m_PrefabInstance: {fileID: 1182776526615740313}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 18698fe9baef4b0488e5c4ab914a10aa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &8900103294415453088 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7775909171457901625, guid: 26c304c542935a646a21dd134e1c2cea, type: 3}
+  m_PrefabInstance: {fileID: 1182776526615740313}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1185155788172301212
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5575222440375443504}
+    m_Modifications:
+    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.067
+      objectReference: {fileID: 0}
+    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.029
+      objectReference: {fileID: 0}
+    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.025
+      objectReference: {fileID: 0}
+    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.49885768
+      objectReference: {fileID: 0}
+    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.50247514
+      objectReference: {fileID: 0}
+    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.49930817
+      objectReference: {fileID: 0}
+    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.49935076
+      objectReference: {fileID: 0}
+    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7383332340980187515, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
+      propertyPath: m_Name
+      value: SMG_LeftDefault
+      objectReference: {fileID: 0}
+    - target: {fileID: 7383332340980187515, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7383332340982194107, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
+--- !u!4 &8504020186838503111 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
+  m_PrefabInstance: {fileID: 1185155788172301212}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1253279215668714220
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 6938851606149577591}
+    m_Modifications:
+    - target: {fileID: 834927088867336716, guid: 63998f5f7f6740f45a2652a1be8e3395, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 834927088867336716, guid: 63998f5f7f6740f45a2652a1be8e3395, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 834927088867336716, guid: 63998f5f7f6740f45a2652a1be8e3395, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 834927088867336716, guid: 63998f5f7f6740f45a2652a1be8e3395, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 834927088867336716, guid: 63998f5f7f6740f45a2652a1be8e3395, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 834927088867336716, guid: 63998f5f7f6740f45a2652a1be8e3395, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 834927088867336716, guid: 63998f5f7f6740f45a2652a1be8e3395, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 834927088867336716, guid: 63998f5f7f6740f45a2652a1be8e3395, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 834927088867336716, guid: 63998f5f7f6740f45a2652a1be8e3395, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 834927088867336716, guid: 63998f5f7f6740f45a2652a1be8e3395, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2251704862427300321, guid: 63998f5f7f6740f45a2652a1be8e3395, type: 3}
+      propertyPath: AbilityTag
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 2251704862427300321, guid: 63998f5f7f6740f45a2652a1be8e3395, type: 3}
+      propertyPath: Equip_state_Tag
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 7079138422186737321, guid: 63998f5f7f6740f45a2652a1be8e3395, type: 3}
+      propertyPath: m_Name
+      value: SkillAttack
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 63998f5f7f6740f45a2652a1be8e3395, type: 3}
+--- !u!4 &1941837650190776544 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 834927088867336716, guid: 63998f5f7f6740f45a2652a1be8e3395, type: 3}
+  m_PrefabInstance: {fileID: 1253279215668714220}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2182230406818659172
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5914098565606461513}
+    m_Modifications:
+    - target: {fileID: 3506613558081934798, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
+    - target: {fileID: 3506613558083865358, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
+      propertyPath: m_Name
+      value: ChemicalGunDefault
+      objectReference: {fileID: 0}
+    - target: {fileID: 3506613558083865358, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
+      propertyPath: m_RootOrder
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.075
+      objectReference: {fileID: 0}
+    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.031
+      objectReference: {fileID: 0}
+    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.011
+      objectReference: {fileID: 0}
+    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.5024751
+      objectReference: {fileID: 0}
+    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.49885765
+      objectReference: {fileID: 0}
+    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.4993508
+      objectReference: {fileID: 0}
+    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.49930817
+      objectReference: {fileID: 0}
+    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
+--- !u!4 &3378025785827044426 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
+  m_PrefabInstance: {fileID: 2182230406818659172}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2702391782149285816
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5914098565606461513}
     m_Modifications:
     - target: {fileID: 1801837882128536133, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
       propertyPath: 'm_Materials.Array.data[0]'
@@ -9099,10 +8711,15 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
---- !u!114 &1020899677359043502 stripped
+--- !u!4 &4359969340327032605 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1801837882130305189, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
+  m_PrefabInstance: {fileID: 2702391782149285816}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &8197751098420373358 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 6072136745390653654, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
-  m_PrefabInstance: {fileID: 6516258866946159480}
+  m_PrefabInstance: {fileID: 2702391782149285816}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
@@ -9110,18 +8727,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 18698fe9baef4b0488e5c4ab914a10aa, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &4859116730437903325 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1801837882130305189, guid: 0ad09dd81121ac247850956387ca9111, type: 3}
-  m_PrefabInstance: {fileID: 6516258866946159480}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &7073811459676617510
+--- !u!1001 &3579387666729655616
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 2157046098051586499}
+    m_TransformParent: {fileID: 5914098565606461513}
     m_Modifications:
     - target: {fileID: 1247223829425721374, guid: f3aa0537edf19a840a5ee3762f7bb9ed, type: 3}
       propertyPath: m_Name
@@ -9184,10 +8796,15 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f3aa0537edf19a840a5ee3762f7bb9ed, type: 3}
---- !u!114 &1379439075492843939 stripped
+--- !u!4 &2369893309570142590 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1247223829425884222, guid: f3aa0537edf19a840a5ee3762f7bb9ed, type: 3}
+  m_PrefabInstance: {fileID: 3579387666729655616}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &4657690215199160261 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 8147005734066317957, guid: f3aa0537edf19a840a5ee3762f7bb9ed, type: 3}
-  m_PrefabInstance: {fileID: 7073811459676617510}
+  m_PrefabInstance: {fileID: 3579387666729655616}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
@@ -9195,388 +8812,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 18698fe9baef4b0488e5c4ab914a10aa, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &8314838422372595480 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1247223829425884222, guid: f3aa0537edf19a840a5ee3762f7bb9ed, type: 3}
-  m_PrefabInstance: {fileID: 7073811459676617510}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &7167681872418826841
+--- !u!1001 &3788506483905040247
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 2157046098051586499}
-    m_Modifications:
-    - target: {fileID: 3823321262689815620, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
-    - target: {fileID: 3823321262691816068, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
-      propertyPath: m_Name
-      value: PistolDefault
-      objectReference: {fileID: 0}
-    - target: {fileID: 3823321262691816068, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
-      propertyPath: m_RootOrder
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.062
-      objectReference: {fileID: 0}
-    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.032
-      objectReference: {fileID: 0}
-    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.004
-      objectReference: {fileID: 0}
-    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.5024751
-      objectReference: {fileID: 0}
-    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.49885765
-      objectReference: {fileID: 0}
-    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.4993508
-      objectReference: {fileID: 0}
-    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.49930817
-      objectReference: {fileID: 0}
-    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
---- !u!4 &6230609969808532733 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
-  m_PrefabInstance: {fileID: 7167681872418826841}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &7505030580713878219
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 2157046098258846160}
-    m_Modifications:
-    - target: {fileID: 3506613558081934798, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
-    - target: {fileID: 3506613558083865358, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
-      propertyPath: m_Name
-      value: ChemicalGun_LeftDefault
-      objectReference: {fileID: 0}
-    - target: {fileID: 3506613558083865358, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
-      propertyPath: m_RootOrder
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.077
-      objectReference: {fileID: 0}
-    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.035
-      objectReference: {fileID: 0}
-    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.006
-      objectReference: {fileID: 0}
-    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.49885768
-      objectReference: {fileID: 0}
-    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.50247514
-      objectReference: {fileID: 0}
-    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.49930817
-      objectReference: {fileID: 0}
-    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.49935076
-      objectReference: {fileID: 0}
-    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
---- !u!4 &6381257622104516069 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
-  m_PrefabInstance: {fileID: 7505030580713878219}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &8614491565306220273
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 2157046098051586499}
-    m_Modifications:
-    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
-      propertyPath: m_RootOrder
-      value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.062
-      objectReference: {fileID: 0}
-    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.011
-      objectReference: {fileID: 0}
-    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.029
-      objectReference: {fileID: 0}
-    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.5024751
-      objectReference: {fileID: 0}
-    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.49885765
-      objectReference: {fileID: 0}
-    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.4993508
-      objectReference: {fileID: 0}
-    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.49930817
-      objectReference: {fileID: 0}
-    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7383332340980187515, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
-      propertyPath: m_Name
-      value: SMGDefault
-      objectReference: {fileID: 0}
-    - target: {fileID: 7383332340980187515, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7383332340982194107, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
---- !u!4 &1295365205838893994 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
-  m_PrefabInstance: {fileID: 8614491565306220273}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &8689185238735667599
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 2157046098051586499}
-    m_Modifications:
-    - target: {fileID: 8105082179318007125, guid: b09ec5d8c38278946a04894adb8f59e2, type: 3}
-      propertyPath: m_RootOrder
-      value: 16
-      objectReference: {fileID: 0}
-    - target: {fileID: 8105082179318007125, guid: b09ec5d8c38278946a04894adb8f59e2, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.06
-      objectReference: {fileID: 0}
-    - target: {fileID: 8105082179318007125, guid: b09ec5d8c38278946a04894adb8f59e2, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.034
-      objectReference: {fileID: 0}
-    - target: {fileID: 8105082179318007125, guid: b09ec5d8c38278946a04894adb8f59e2, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.065
-      objectReference: {fileID: 0}
-    - target: {fileID: 8105082179318007125, guid: b09ec5d8c38278946a04894adb8f59e2, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.5024751
-      objectReference: {fileID: 0}
-    - target: {fileID: 8105082179318007125, guid: b09ec5d8c38278946a04894adb8f59e2, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.49885765
-      objectReference: {fileID: 0}
-    - target: {fileID: 8105082179318007125, guid: b09ec5d8c38278946a04894adb8f59e2, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.4993508
-      objectReference: {fileID: 0}
-    - target: {fileID: 8105082179318007125, guid: b09ec5d8c38278946a04894adb8f59e2, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.49930817
-      objectReference: {fileID: 0}
-    - target: {fileID: 8105082179318007125, guid: b09ec5d8c38278946a04894adb8f59e2, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8105082179318007125, guid: b09ec5d8c38278946a04894adb8f59e2, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8105082179318007125, guid: b09ec5d8c38278946a04894adb8f59e2, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8105082179318372725, guid: b09ec5d8c38278946a04894adb8f59e2, type: 3}
-      propertyPath: m_Name
-      value: HuntingRifleDefault
-      objectReference: {fileID: 0}
-    - target: {fileID: 8105082179318372725, guid: b09ec5d8c38278946a04894adb8f59e2, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8105082179320301493, guid: b09ec5d8c38278946a04894adb8f59e2, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: b09ec5d8c38278946a04894adb8f59e2, type: 3}
---- !u!4 &643212804847895770 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8105082179318007125, guid: b09ec5d8c38278946a04894adb8f59e2, type: 3}
-  m_PrefabInstance: {fileID: 8689185238735667599}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &8878470189261847539
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 2157046098051586499}
-    m_Modifications:
-    - target: {fileID: 5494131160747400176, guid: 0af9ef9f43e952441a60d5ec8dbbbc3a, type: 3}
-      propertyPath: m_Name
-      value: SmokeGrenadeDefault
-      objectReference: {fileID: 0}
-    - target: {fileID: 5494131160747400176, guid: 0af9ef9f43e952441a60d5ec8dbbbc3a, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5494131160747821008, guid: 0af9ef9f43e952441a60d5ec8dbbbc3a, type: 3}
-      propertyPath: m_RootOrder
-      value: 22
-      objectReference: {fileID: 0}
-    - target: {fileID: 5494131160747821008, guid: 0af9ef9f43e952441a60d5ec8dbbbc3a, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.145
-      objectReference: {fileID: 0}
-    - target: {fileID: 5494131160747821008, guid: 0af9ef9f43e952441a60d5ec8dbbbc3a, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.098
-      objectReference: {fileID: 0}
-    - target: {fileID: 5494131160747821008, guid: 0af9ef9f43e952441a60d5ec8dbbbc3a, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.015
-      objectReference: {fileID: 0}
-    - target: {fileID: 5494131160747821008, guid: 0af9ef9f43e952441a60d5ec8dbbbc3a, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.5024751
-      objectReference: {fileID: 0}
-    - target: {fileID: 5494131160747821008, guid: 0af9ef9f43e952441a60d5ec8dbbbc3a, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.49885765
-      objectReference: {fileID: 0}
-    - target: {fileID: 5494131160747821008, guid: 0af9ef9f43e952441a60d5ec8dbbbc3a, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.4993508
-      objectReference: {fileID: 0}
-    - target: {fileID: 5494131160747821008, guid: 0af9ef9f43e952441a60d5ec8dbbbc3a, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.49930817
-      objectReference: {fileID: 0}
-    - target: {fileID: 5494131160747821008, guid: 0af9ef9f43e952441a60d5ec8dbbbc3a, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5494131160747821008, guid: 0af9ef9f43e952441a60d5ec8dbbbc3a, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5494131160747821008, guid: 0af9ef9f43e952441a60d5ec8dbbbc3a, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5494131160749589808, guid: 0af9ef9f43e952441a60d5ec8dbbbc3a, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 0af9ef9f43e952441a60d5ec8dbbbc3a, type: 3}
---- !u!4 &3965906240577453091 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5494131160747821008, guid: 0af9ef9f43e952441a60d5ec8dbbbc3a, type: 3}
-  m_PrefabInstance: {fileID: 8878470189261847539}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &8948886551567757710
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 2157046098258846160}
+    m_TransformParent: {fileID: 5575222440375443504}
     m_Modifications:
     - target: {fileID: 8842376448992230921, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
       propertyPath: 'm_Materials.Array.data[0]'
@@ -9639,72 +8881,72 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
---- !u!4 &470268200330092199 stripped
+--- !u!4 &5630929016078573662 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8842376448995045161, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
-  m_PrefabInstance: {fileID: 8948886551567757710}
+  m_PrefabInstance: {fileID: 3788506483905040247}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &9159743962103910302
+--- !u!1001 &3840175007842888568
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 2157046098051586499}
+    m_TransformParent: {fileID: 5914098565606461513}
     m_Modifications:
-    - target: {fileID: 7775909171456001753, guid: 26c304c542935a646a21dd134e1c2cea, type: 3}
+    - target: {fileID: 8842376448992230921, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
       propertyPath: 'm_Materials.Array.data[0]'
       value: 
       objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
-    - target: {fileID: 7775909171457901625, guid: 26c304c542935a646a21dd134e1c2cea, type: 3}
+    - target: {fileID: 8842376448995045161, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 9
       objectReference: {fileID: 0}
-    - target: {fileID: 7775909171457901625, guid: 26c304c542935a646a21dd134e1c2cea, type: 3}
+    - target: {fileID: 8842376448995045161, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.0692
+      value: 0.22065039
       objectReference: {fileID: 0}
-    - target: {fileID: 7775909171457901625, guid: 26c304c542935a646a21dd134e1c2cea, type: 3}
+    - target: {fileID: 8842376448995045161, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.036
+      value: -0.02834493
       objectReference: {fileID: 0}
-    - target: {fileID: 7775909171457901625, guid: 26c304c542935a646a21dd134e1c2cea, type: 3}
+    - target: {fileID: 8842376448995045161, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.014
+      value: 0.15955243
       objectReference: {fileID: 0}
-    - target: {fileID: 7775909171457901625, guid: 26c304c542935a646a21dd134e1c2cea, type: 3}
+    - target: {fileID: 8842376448995045161, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
       propertyPath: m_LocalRotation.w
       value: 0.5024751
       objectReference: {fileID: 0}
-    - target: {fileID: 7775909171457901625, guid: 26c304c542935a646a21dd134e1c2cea, type: 3}
+    - target: {fileID: 8842376448995045161, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0.49885765
       objectReference: {fileID: 0}
-    - target: {fileID: 7775909171457901625, guid: 26c304c542935a646a21dd134e1c2cea, type: 3}
+    - target: {fileID: 8842376448995045161, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0.4993508
       objectReference: {fileID: 0}
-    - target: {fileID: 7775909171457901625, guid: 26c304c542935a646a21dd134e1c2cea, type: 3}
+    - target: {fileID: 8842376448995045161, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0.49930817
       objectReference: {fileID: 0}
-    - target: {fileID: 7775909171457901625, guid: 26c304c542935a646a21dd134e1c2cea, type: 3}
+    - target: {fileID: 8842376448995045161, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7775909171457901625, guid: 26c304c542935a646a21dd134e1c2cea, type: 3}
+    - target: {fileID: 8842376448995045161, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7775909171457901625, guid: 26c304c542935a646a21dd134e1c2cea, type: 3}
+    - target: {fileID: 8842376448995045161, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7775909171458005017, guid: 26c304c542935a646a21dd134e1c2cea, type: 3}
+    - target: {fileID: 8842376448995406601, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
       propertyPath: m_Name
-      value: AssaultRifle
+      value: ElectricGunDefault
       objectReference: {fileID: 0}
-    - target: {fileID: 7775909171458005017, guid: 26c304c542935a646a21dd134e1c2cea, type: 3}
+    - target: {fileID: 8842376448995406601, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
@@ -9712,20 +8954,1119 @@ PrefabInstance:
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 26c304c542935a646a21dd134e1c2cea, type: 3}
---- !u!4 &1509944659781667751 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
+--- !u!4 &5763873439529026641 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 7775909171457901625, guid: 26c304c542935a646a21dd134e1c2cea, type: 3}
-  m_PrefabInstance: {fileID: 9159743962103910302}
+  m_CorrespondingSourceObject: {fileID: 8842376448995045161, guid: 71c7a22b614cbb443877d9ba29e9999d, type: 3}
+  m_PrefabInstance: {fileID: 3840175007842888568}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &2681370085982890864 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6497517203303556334, guid: 26c304c542935a646a21dd134e1c2cea, type: 3}
-  m_PrefabInstance: {fileID: 9159743962103910302}
+--- !u!1001 &3886962010695761190
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5914098565606461513}
+    m_Modifications:
+    - target: {fileID: 8105082179318007125, guid: b09ec5d8c38278946a04894adb8f59e2, type: 3}
+      propertyPath: m_RootOrder
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 8105082179318007125, guid: b09ec5d8c38278946a04894adb8f59e2, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.06
+      objectReference: {fileID: 0}
+    - target: {fileID: 8105082179318007125, guid: b09ec5d8c38278946a04894adb8f59e2, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.034
+      objectReference: {fileID: 0}
+    - target: {fileID: 8105082179318007125, guid: b09ec5d8c38278946a04894adb8f59e2, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.065
+      objectReference: {fileID: 0}
+    - target: {fileID: 8105082179318007125, guid: b09ec5d8c38278946a04894adb8f59e2, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.5024751
+      objectReference: {fileID: 0}
+    - target: {fileID: 8105082179318007125, guid: b09ec5d8c38278946a04894adb8f59e2, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.49885765
+      objectReference: {fileID: 0}
+    - target: {fileID: 8105082179318007125, guid: b09ec5d8c38278946a04894adb8f59e2, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.4993508
+      objectReference: {fileID: 0}
+    - target: {fileID: 8105082179318007125, guid: b09ec5d8c38278946a04894adb8f59e2, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.49930817
+      objectReference: {fileID: 0}
+    - target: {fileID: 8105082179318007125, guid: b09ec5d8c38278946a04894adb8f59e2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8105082179318007125, guid: b09ec5d8c38278946a04894adb8f59e2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8105082179318007125, guid: b09ec5d8c38278946a04894adb8f59e2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8105082179318372725, guid: b09ec5d8c38278946a04894adb8f59e2, type: 3}
+      propertyPath: m_Name
+      value: HuntingRifleDefault
+      objectReference: {fileID: 0}
+    - target: {fileID: 8105082179318372725, guid: b09ec5d8c38278946a04894adb8f59e2, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8105082179320301493, guid: b09ec5d8c38278946a04894adb8f59e2, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b09ec5d8c38278946a04894adb8f59e2, type: 3}
+--- !u!4 &5010898995420870771 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8105082179318007125, guid: b09ec5d8c38278946a04894adb8f59e2, type: 3}
+  m_PrefabInstance: {fileID: 3886962010695761190}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 18698fe9baef4b0488e5c4ab914a10aa, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+--- !u!1001 &4824435722756815247
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5914098565606461513}
+    m_Modifications:
+    - target: {fileID: 7780763529669504476, guid: 61865cafb461b3b48a451dca4f88e17a, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
+    - target: {fileID: 7780763529671439132, guid: 61865cafb461b3b48a451dca4f88e17a, type: 3}
+      propertyPath: m_Name
+      value: GrenadeDefault
+      objectReference: {fileID: 0}
+    - target: {fileID: 7780763529671439132, guid: 61865cafb461b3b48a451dca4f88e17a, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7780763529671798588, guid: 61865cafb461b3b48a451dca4f88e17a, type: 3}
+      propertyPath: m_RootOrder
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 7780763529671798588, guid: 61865cafb461b3b48a451dca4f88e17a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.141
+      objectReference: {fileID: 0}
+    - target: {fileID: 7780763529671798588, guid: 61865cafb461b3b48a451dca4f88e17a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.088
+      objectReference: {fileID: 0}
+    - target: {fileID: 7780763529671798588, guid: 61865cafb461b3b48a451dca4f88e17a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.009
+      objectReference: {fileID: 0}
+    - target: {fileID: 7780763529671798588, guid: 61865cafb461b3b48a451dca4f88e17a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.5024751
+      objectReference: {fileID: 0}
+    - target: {fileID: 7780763529671798588, guid: 61865cafb461b3b48a451dca4f88e17a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.49885765
+      objectReference: {fileID: 0}
+    - target: {fileID: 7780763529671798588, guid: 61865cafb461b3b48a451dca4f88e17a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.4993508
+      objectReference: {fileID: 0}
+    - target: {fileID: 7780763529671798588, guid: 61865cafb461b3b48a451dca4f88e17a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.49930817
+      objectReference: {fileID: 0}
+    - target: {fileID: 7780763529671798588, guid: 61865cafb461b3b48a451dca4f88e17a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7780763529671798588, guid: 61865cafb461b3b48a451dca4f88e17a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7780763529671798588, guid: 61865cafb461b3b48a451dca4f88e17a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 61865cafb461b3b48a451dca4f88e17a, type: 3}
+--- !u!4 &2956900738392463027 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7780763529671798588, guid: 61865cafb461b3b48a451dca4f88e17a, type: 3}
+  m_PrefabInstance: {fileID: 4824435722756815247}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5626207221683445364
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5914098565606461513}
+    m_Modifications:
+    - target: {fileID: 2440554163673562166, guid: aa9e0e616408abf4896f703b691204ed, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
+    - target: {fileID: 2440554163675463382, guid: aa9e0e616408abf4896f703b691204ed, type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2440554163675463382, guid: aa9e0e616408abf4896f703b691204ed, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.095
+      objectReference: {fileID: 0}
+    - target: {fileID: 2440554163675463382, guid: aa9e0e616408abf4896f703b691204ed, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.032
+      objectReference: {fileID: 0}
+    - target: {fileID: 2440554163675463382, guid: aa9e0e616408abf4896f703b691204ed, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2440554163675463382, guid: aa9e0e616408abf4896f703b691204ed, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.5024751
+      objectReference: {fileID: 0}
+    - target: {fileID: 2440554163675463382, guid: aa9e0e616408abf4896f703b691204ed, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.49885765
+      objectReference: {fileID: 0}
+    - target: {fileID: 2440554163675463382, guid: aa9e0e616408abf4896f703b691204ed, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.4993508
+      objectReference: {fileID: 0}
+    - target: {fileID: 2440554163675463382, guid: aa9e0e616408abf4896f703b691204ed, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.49930817
+      objectReference: {fileID: 0}
+    - target: {fileID: 2440554163675463382, guid: aa9e0e616408abf4896f703b691204ed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2440554163675463382, guid: aa9e0e616408abf4896f703b691204ed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2440554163675463382, guid: aa9e0e616408abf4896f703b691204ed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2440554163675751158, guid: aa9e0e616408abf4896f703b691204ed, type: 3}
+      propertyPath: m_Name
+      value: GravityGunDefault
+      objectReference: {fileID: 0}
+    - target: {fileID: 2440554163675751158, guid: aa9e0e616408abf4896f703b691204ed, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aa9e0e616408abf4896f703b691204ed, type: 3}
+--- !u!4 &8055491384726266018 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2440554163675463382, guid: aa9e0e616408abf4896f703b691204ed, type: 3}
+  m_PrefabInstance: {fileID: 5626207221683445364}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5938745275877917520
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5575222440375443504}
+    m_Modifications:
+    - target: {fileID: 3506613558081934798, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
+    - target: {fileID: 3506613558083865358, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
+      propertyPath: m_Name
+      value: ChemicalGun_LeftDefault
+      objectReference: {fileID: 0}
+    - target: {fileID: 3506613558083865358, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.077
+      objectReference: {fileID: 0}
+    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.035
+      objectReference: {fileID: 0}
+    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.006
+      objectReference: {fileID: 0}
+    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.49885768
+      objectReference: {fileID: 0}
+    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.50247514
+      objectReference: {fileID: 0}
+    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.49930817
+      objectReference: {fileID: 0}
+    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.49935076
+      objectReference: {fileID: 0}
+    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
+--- !u!4 &7116627694780175486 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3506613558084359982, guid: ce5dc50b63174014f92200f39ed282d1, type: 3}
+  m_PrefabInstance: {fileID: 5938745275877917520}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &6611565231040545757
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5914098565606461513}
+    m_Modifications:
+    - target: {fileID: 5494131160747400176, guid: 0af9ef9f43e952441a60d5ec8dbbbc3a, type: 3}
+      propertyPath: m_Name
+      value: SmokeGrenadeDefault
+      objectReference: {fileID: 0}
+    - target: {fileID: 5494131160747400176, guid: 0af9ef9f43e952441a60d5ec8dbbbc3a, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5494131160747821008, guid: 0af9ef9f43e952441a60d5ec8dbbbc3a, type: 3}
+      propertyPath: m_RootOrder
+      value: 22
+      objectReference: {fileID: 0}
+    - target: {fileID: 5494131160747821008, guid: 0af9ef9f43e952441a60d5ec8dbbbc3a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.145
+      objectReference: {fileID: 0}
+    - target: {fileID: 5494131160747821008, guid: 0af9ef9f43e952441a60d5ec8dbbbc3a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.098
+      objectReference: {fileID: 0}
+    - target: {fileID: 5494131160747821008, guid: 0af9ef9f43e952441a60d5ec8dbbbc3a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.015
+      objectReference: {fileID: 0}
+    - target: {fileID: 5494131160747821008, guid: 0af9ef9f43e952441a60d5ec8dbbbc3a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.5024751
+      objectReference: {fileID: 0}
+    - target: {fileID: 5494131160747821008, guid: 0af9ef9f43e952441a60d5ec8dbbbc3a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.49885765
+      objectReference: {fileID: 0}
+    - target: {fileID: 5494131160747821008, guid: 0af9ef9f43e952441a60d5ec8dbbbc3a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.4993508
+      objectReference: {fileID: 0}
+    - target: {fileID: 5494131160747821008, guid: 0af9ef9f43e952441a60d5ec8dbbbc3a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.49930817
+      objectReference: {fileID: 0}
+    - target: {fileID: 5494131160747821008, guid: 0af9ef9f43e952441a60d5ec8dbbbc3a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5494131160747821008, guid: 0af9ef9f43e952441a60d5ec8dbbbc3a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5494131160747821008, guid: 0af9ef9f43e952441a60d5ec8dbbbc3a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5494131160749589808, guid: 0af9ef9f43e952441a60d5ec8dbbbc3a, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0af9ef9f43e952441a60d5ec8dbbbc3a, type: 3}
+--- !u!4 &1729360963346990093 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5494131160747821008, guid: 0af9ef9f43e952441a60d5ec8dbbbc3a, type: 3}
+  m_PrefabInstance: {fileID: 6611565231040545757}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7170143756102331047
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5914098565606461513}
+    m_Modifications:
+    - target: {fileID: 3323609523919431078, guid: d4481c76bd8df8844b540671759a53e0, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
+    - target: {fileID: 3323609523921369958, guid: d4481c76bd8df8844b540671759a53e0, type: 3}
+      propertyPath: m_Name
+      value: SniperRifleDefault
+      objectReference: {fileID: 0}
+    - target: {fileID: 3323609523921369958, guid: d4481c76bd8df8844b540671759a53e0, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3323609523921856326, guid: d4481c76bd8df8844b540671759a53e0, type: 3}
+      propertyPath: m_RootOrder
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 3323609523921856326, guid: d4481c76bd8df8844b540671759a53e0, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.039
+      objectReference: {fileID: 0}
+    - target: {fileID: 3323609523921856326, guid: d4481c76bd8df8844b540671759a53e0, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.018
+      objectReference: {fileID: 0}
+    - target: {fileID: 3323609523921856326, guid: d4481c76bd8df8844b540671759a53e0, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.006
+      objectReference: {fileID: 0}
+    - target: {fileID: 3323609523921856326, guid: d4481c76bd8df8844b540671759a53e0, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.5024751
+      objectReference: {fileID: 0}
+    - target: {fileID: 3323609523921856326, guid: d4481c76bd8df8844b540671759a53e0, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.49885765
+      objectReference: {fileID: 0}
+    - target: {fileID: 3323609523921856326, guid: d4481c76bd8df8844b540671759a53e0, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.4993508
+      objectReference: {fileID: 0}
+    - target: {fileID: 3323609523921856326, guid: d4481c76bd8df8844b540671759a53e0, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.49930817
+      objectReference: {fileID: 0}
+    - target: {fileID: 3323609523921856326, guid: d4481c76bd8df8844b540671759a53e0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3323609523921856326, guid: d4481c76bd8df8844b540671759a53e0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3323609523921856326, guid: d4481c76bd8df8844b540671759a53e0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d4481c76bd8df8844b540671759a53e0, type: 3}
+--- !u!4 &5593086463911742945 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3323609523921856326, guid: d4481c76bd8df8844b540671759a53e0, type: 3}
+  m_PrefabInstance: {fileID: 7170143756102331047}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7283658811017084710
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5914098565606461513}
+    m_Modifications:
+    - target: {fileID: 1541296155195428663, guid: 7b2284d4a9faf474492e3b11a78a77ca, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
+    - target: {fileID: 1541296155197690359, guid: 7b2284d4a9faf474492e3b11a78a77ca, type: 3}
+      propertyPath: m_Name
+      value: KnifeDefault
+      objectReference: {fileID: 0}
+    - target: {fileID: 1541296155197690359, guid: 7b2284d4a9faf474492e3b11a78a77ca, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1541296155197722071, guid: 7b2284d4a9faf474492e3b11a78a77ca, type: 3}
+      propertyPath: m_RootOrder
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 1541296155197722071, guid: 7b2284d4a9faf474492e3b11a78a77ca, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.094
+      objectReference: {fileID: 0}
+    - target: {fileID: 1541296155197722071, guid: 7b2284d4a9faf474492e3b11a78a77ca, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.028
+      objectReference: {fileID: 0}
+    - target: {fileID: 1541296155197722071, guid: 7b2284d4a9faf474492e3b11a78a77ca, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 1541296155197722071, guid: 7b2284d4a9faf474492e3b11a78a77ca, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7080492
+      objectReference: {fileID: 0}
+    - target: {fileID: 1541296155197722071, guid: 7b2284d4a9faf474492e3b11a78a77ca, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.0025578432
+      objectReference: {fileID: 0}
+    - target: {fileID: 1541296155197722071, guid: 7b2284d4a9faf474492e3b11a78a77ca, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.000030159943
+      objectReference: {fileID: 0}
+    - target: {fileID: 1541296155197722071, guid: 7b2284d4a9faf474492e3b11a78a77ca, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.70615846
+      objectReference: {fileID: 0}
+    - target: {fileID: 1541296155197722071, guid: 7b2284d4a9faf474492e3b11a78a77ca, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: 1541296155197722071, guid: 7b2284d4a9faf474492e3b11a78a77ca, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1541296155197722071, guid: 7b2284d4a9faf474492e3b11a78a77ca, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7b2284d4a9faf474492e3b11a78a77ca, type: 3}
+--- !u!4 &8103956736058946289 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1541296155197722071, guid: 7b2284d4a9faf474492e3b11a78a77ca, type: 3}
+  m_PrefabInstance: {fileID: 7283658811017084710}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7461059257594916485
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5914098565606461513}
+    m_Modifications:
+    - target: {fileID: 3823321262689815620, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
+    - target: {fileID: 3823321262691816068, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
+      propertyPath: m_Name
+      value: PistolDefault
+      objectReference: {fileID: 0}
+    - target: {fileID: 3823321262691816068, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.062
+      objectReference: {fileID: 0}
+    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.032
+      objectReference: {fileID: 0}
+    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.004
+      objectReference: {fileID: 0}
+    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.5024751
+      objectReference: {fileID: 0}
+    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.49885765
+      objectReference: {fileID: 0}
+    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.4993508
+      objectReference: {fileID: 0}
+    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.49930817
+      objectReference: {fileID: 0}
+    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
+--- !u!4 &5945925456739147809 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
+  m_PrefabInstance: {fileID: 7461059257594916485}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7464797770267733313
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5914098565606461513}
+    m_Modifications:
+    - target: {fileID: 2797637213908180465, guid: ca77f62d2888f6c4a874efb77151ed72, type: 3}
+      propertyPath: m_RootOrder
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 2797637213908180465, guid: ca77f62d2888f6c4a874efb77151ed72, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.109
+      objectReference: {fileID: 0}
+    - target: {fileID: 2797637213908180465, guid: ca77f62d2888f6c4a874efb77151ed72, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2797637213908180465, guid: ca77f62d2888f6c4a874efb77151ed72, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.142
+      objectReference: {fileID: 0}
+    - target: {fileID: 2797637213908180465, guid: ca77f62d2888f6c4a874efb77151ed72, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.5024751
+      objectReference: {fileID: 0}
+    - target: {fileID: 2797637213908180465, guid: ca77f62d2888f6c4a874efb77151ed72, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.49885765
+      objectReference: {fileID: 0}
+    - target: {fileID: 2797637213908180465, guid: ca77f62d2888f6c4a874efb77151ed72, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.4993508
+      objectReference: {fileID: 0}
+    - target: {fileID: 2797637213908180465, guid: ca77f62d2888f6c4a874efb77151ed72, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.49930817
+      objectReference: {fileID: 0}
+    - target: {fileID: 2797637213908180465, guid: ca77f62d2888f6c4a874efb77151ed72, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2797637213908180465, guid: ca77f62d2888f6c4a874efb77151ed72, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2797637213908180465, guid: ca77f62d2888f6c4a874efb77151ed72, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2797637213908533713, guid: ca77f62d2888f6c4a874efb77151ed72, type: 3}
+      propertyPath: m_Name
+      value: CrossBowDefault
+      objectReference: {fileID: 0}
+    - target: {fileID: 2797637213908533713, guid: ca77f62d2888f6c4a874efb77151ed72, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2797637213913746641, guid: ca77f62d2888f6c4a874efb77151ed72, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ca77f62d2888f6c4a874efb77151ed72, type: 3}
+--- !u!4 &4704993034591711408 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2797637213908180465, guid: ca77f62d2888f6c4a874efb77151ed72, type: 3}
+  m_PrefabInstance: {fileID: 7464797770267733313}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7717145144037274392
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5914098565606461513}
+    m_Modifications:
+    - target: {fileID: 2031753809481465525, guid: 1f1289a1c8e71ab4f9f8050e0a78c9ca, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
+    - target: {fileID: 2031753809493029809, guid: 1f1289a1c8e71ab4f9f8050e0a78c9ca, type: 3}
+      propertyPath: m_Name
+      value: ShotgunDefault
+      objectReference: {fileID: 0}
+    - target: {fileID: 2031753809493029809, guid: 1f1289a1c8e71ab4f9f8050e0a78c9ca, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2031753809493454737, guid: 1f1289a1c8e71ab4f9f8050e0a78c9ca, type: 3}
+      propertyPath: m_RootOrder
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 2031753809493454737, guid: 1f1289a1c8e71ab4f9f8050e0a78c9ca, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.068
+      objectReference: {fileID: 0}
+    - target: {fileID: 2031753809493454737, guid: 1f1289a1c8e71ab4f9f8050e0a78c9ca, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.053
+      objectReference: {fileID: 0}
+    - target: {fileID: 2031753809493454737, guid: 1f1289a1c8e71ab4f9f8050e0a78c9ca, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.116
+      objectReference: {fileID: 0}
+    - target: {fileID: 2031753809493454737, guid: 1f1289a1c8e71ab4f9f8050e0a78c9ca, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.5024751
+      objectReference: {fileID: 0}
+    - target: {fileID: 2031753809493454737, guid: 1f1289a1c8e71ab4f9f8050e0a78c9ca, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.49885765
+      objectReference: {fileID: 0}
+    - target: {fileID: 2031753809493454737, guid: 1f1289a1c8e71ab4f9f8050e0a78c9ca, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.4993508
+      objectReference: {fileID: 0}
+    - target: {fileID: 2031753809493454737, guid: 1f1289a1c8e71ab4f9f8050e0a78c9ca, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.49930817
+      objectReference: {fileID: 0}
+    - target: {fileID: 2031753809493454737, guid: 1f1289a1c8e71ab4f9f8050e0a78c9ca, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2031753809493454737, guid: 1f1289a1c8e71ab4f9f8050e0a78c9ca, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2031753809493454737, guid: 1f1289a1c8e71ab4f9f8050e0a78c9ca, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1f1289a1c8e71ab4f9f8050e0a78c9ca, type: 3}
+--- !u!4 &8586943698034465929 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2031753809493454737, guid: 1f1289a1c8e71ab4f9f8050e0a78c9ca, type: 3}
+  m_PrefabInstance: {fileID: 7717145144037274392}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8247545025923665873
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5914098565606461513}
+    m_Modifications:
+    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
+      propertyPath: m_RootOrder
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.062
+      objectReference: {fileID: 0}
+    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.011
+      objectReference: {fileID: 0}
+    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.029
+      objectReference: {fileID: 0}
+    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.5024751
+      objectReference: {fileID: 0}
+    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.49885765
+      objectReference: {fileID: 0}
+    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.4993508
+      objectReference: {fileID: 0}
+    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.49930817
+      objectReference: {fileID: 0}
+    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7383332340980187515, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
+      propertyPath: m_Name
+      value: SMGDefault
+      objectReference: {fileID: 0}
+    - target: {fileID: 7383332340980187515, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7383332340982194107, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
+--- !u!4 &1442268046960415370 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7383332340979768667, guid: 6a699b542f767504c9d47c83674ad4d9, type: 3}
+  m_PrefabInstance: {fileID: 8247545025923665873}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8285109610057941946
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5914098565606461513}
+    m_Modifications:
+    - target: {fileID: 4982128866425352390, guid: 77c66d64e7d1a8b458934029d50fcbf1, type: 3}
+      propertyPath: m_Name
+      value: FlameThrowerDefault
+      objectReference: {fileID: 0}
+    - target: {fileID: 4982128866425352390, guid: 77c66d64e7d1a8b458934029d50fcbf1, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4982128866425777382, guid: 77c66d64e7d1a8b458934029d50fcbf1, type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4982128866425777382, guid: 77c66d64e7d1a8b458934029d50fcbf1, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.076
+      objectReference: {fileID: 0}
+    - target: {fileID: 4982128866425777382, guid: 77c66d64e7d1a8b458934029d50fcbf1, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.046
+      objectReference: {fileID: 0}
+    - target: {fileID: 4982128866425777382, guid: 77c66d64e7d1a8b458934029d50fcbf1, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.012
+      objectReference: {fileID: 0}
+    - target: {fileID: 4982128866425777382, guid: 77c66d64e7d1a8b458934029d50fcbf1, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.5024751
+      objectReference: {fileID: 0}
+    - target: {fileID: 4982128866425777382, guid: 77c66d64e7d1a8b458934029d50fcbf1, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.49885765
+      objectReference: {fileID: 0}
+    - target: {fileID: 4982128866425777382, guid: 77c66d64e7d1a8b458934029d50fcbf1, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.4993508
+      objectReference: {fileID: 0}
+    - target: {fileID: 4982128866425777382, guid: 77c66d64e7d1a8b458934029d50fcbf1, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.49930817
+      objectReference: {fileID: 0}
+    - target: {fileID: 4982128866425777382, guid: 77c66d64e7d1a8b458934029d50fcbf1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4982128866425777382, guid: 77c66d64e7d1a8b458934029d50fcbf1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4982128866425777382, guid: 77c66d64e7d1a8b458934029d50fcbf1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4982128866427547142, guid: 77c66d64e7d1a8b458934029d50fcbf1, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77c66d64e7d1a8b458934029d50fcbf1, type: 3}
+--- !u!4 &4025809624005013340 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4982128866425777382, guid: 77c66d64e7d1a8b458934029d50fcbf1, type: 3}
+  m_PrefabInstance: {fileID: 8285109610057941946}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8760782703168409962
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5914098565606461513}
+    m_Modifications:
+    - target: {fileID: 2196376887936773799, guid: 79cfad6d28604f54a97b32d45af9d2b2, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
+    - target: {fileID: 2196376887939949475, guid: 79cfad6d28604f54a97b32d45af9d2b2, type: 3}
+      propertyPath: m_Name
+      value: MiniGunDefault
+      objectReference: {fileID: 0}
+    - target: {fileID: 2196376887939949475, guid: 79cfad6d28604f54a97b32d45af9d2b2, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2196376887940251523, guid: 79cfad6d28604f54a97b32d45af9d2b2, type: 3}
+      propertyPath: m_RootOrder
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 2196376887940251523, guid: 79cfad6d28604f54a97b32d45af9d2b2, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.099
+      objectReference: {fileID: 0}
+    - target: {fileID: 2196376887940251523, guid: 79cfad6d28604f54a97b32d45af9d2b2, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.237
+      objectReference: {fileID: 0}
+    - target: {fileID: 2196376887940251523, guid: 79cfad6d28604f54a97b32d45af9d2b2, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.109
+      objectReference: {fileID: 0}
+    - target: {fileID: 2196376887940251523, guid: 79cfad6d28604f54a97b32d45af9d2b2, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.5024751
+      objectReference: {fileID: 0}
+    - target: {fileID: 2196376887940251523, guid: 79cfad6d28604f54a97b32d45af9d2b2, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.49885765
+      objectReference: {fileID: 0}
+    - target: {fileID: 2196376887940251523, guid: 79cfad6d28604f54a97b32d45af9d2b2, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.4993508
+      objectReference: {fileID: 0}
+    - target: {fileID: 2196376887940251523, guid: 79cfad6d28604f54a97b32d45af9d2b2, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.49930817
+      objectReference: {fileID: 0}
+    - target: {fileID: 2196376887940251523, guid: 79cfad6d28604f54a97b32d45af9d2b2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2196376887940251523, guid: 79cfad6d28604f54a97b32d45af9d2b2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2196376887940251523, guid: 79cfad6d28604f54a97b32d45af9d2b2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 79cfad6d28604f54a97b32d45af9d2b2, type: 3}
+--- !u!4 &7489367807632813801 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2196376887940251523, guid: 79cfad6d28604f54a97b32d45af9d2b2, type: 3}
+  m_PrefabInstance: {fileID: 8760782703168409962}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8844648787975060530
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5914098565606461513}
+    m_Modifications:
+    - target: {fileID: 5416553806754953150, guid: 2cecb33133bf7b249b23daad68d0df10, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
+    - target: {fileID: 5416553806760229562, guid: 2cecb33133bf7b249b23daad68d0df10, type: 3}
+      propertyPath: m_Name
+      value: SawGunDefault
+      objectReference: {fileID: 0}
+    - target: {fileID: 5416553806760229562, guid: 2cecb33133bf7b249b23daad68d0df10, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5416553806760257178, guid: 2cecb33133bf7b249b23daad68d0df10, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5416553806760257178, guid: 2cecb33133bf7b249b23daad68d0df10, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.1693875
+      objectReference: {fileID: 0}
+    - target: {fileID: 5416553806760257178, guid: 2cecb33133bf7b249b23daad68d0df10, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.021226466
+      objectReference: {fileID: 0}
+    - target: {fileID: 5416553806760257178, guid: 2cecb33133bf7b249b23daad68d0df10, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.1543433
+      objectReference: {fileID: 0}
+    - target: {fileID: 5416553806760257178, guid: 2cecb33133bf7b249b23daad68d0df10, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.5024751
+      objectReference: {fileID: 0}
+    - target: {fileID: 5416553806760257178, guid: 2cecb33133bf7b249b23daad68d0df10, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.4988577
+      objectReference: {fileID: 0}
+    - target: {fileID: 5416553806760257178, guid: 2cecb33133bf7b249b23daad68d0df10, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.4993508
+      objectReference: {fileID: 0}
+    - target: {fileID: 5416553806760257178, guid: 2cecb33133bf7b249b23daad68d0df10, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.4993081
+      objectReference: {fileID: 0}
+    - target: {fileID: 5416553806760257178, guid: 2cecb33133bf7b249b23daad68d0df10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5416553806760257178, guid: 2cecb33133bf7b249b23daad68d0df10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5416553806760257178, guid: 2cecb33133bf7b249b23daad68d0df10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2cecb33133bf7b249b23daad68d0df10, type: 3}
+--- !u!4 &3573034330721327784 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5416553806760257178, guid: 2cecb33133bf7b249b23daad68d0df10, type: 3}
+  m_PrefabInstance: {fileID: 8844648787975060530}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &9082350667355028076
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5575222440375443504}
+    m_Modifications:
+    - target: {fileID: 3823321262689815620, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: f46d64b56f1dfcf4e9e43dbed6748fe9, type: 2}
+    - target: {fileID: 3823321262691816068, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
+      propertyPath: m_Name
+      value: Pistol_LeftDefault
+      objectReference: {fileID: 0}
+    - target: {fileID: 3823321262691816068, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.077
+      objectReference: {fileID: 0}
+    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.023
+      objectReference: {fileID: 0}
+    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.49885768
+      objectReference: {fileID: 0}
+    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.50247514
+      objectReference: {fileID: 0}
+    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.49930817
+      objectReference: {fileID: 0}
+    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.49935076
+      objectReference: {fileID: 0}
+    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
+--- !u!4 &5405964017335039176 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3823321262692109988, guid: 226c568e48d1bbc45a3110f8660d2e2c, type: 3}
+  m_PrefabInstance: {fileID: 9082350667355028076}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/Character/Player.prefab.meta
+++ b/Assets/Prefabs/Character/Player.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4435ca00a4b7ed94ba6a732efa843ae2
+guid: 9f8e21282b3b1884183c7faeaf0b8313
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Assets/Prefabs/Monster/BlackHood.prefab
+++ b/Assets/Prefabs/Monster/BlackHood.prefab
@@ -51,11 +51,26 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   attribute:
-    MaxHart: 5
-    CurHart: 5
-    atk: 1
-    attackSpeed: 1
-    speed: 1
+    Health:
+      AttributeName: Health
+      MaxValue: 10
+      BaseValue: 0
+      CurValue: 0
+    Attack:
+      AttributeName: Attack
+      MaxValue: 10
+      BaseValue: 0
+      CurValue: 0
+    AttackSpeed:
+      AttributeName: AttackSpeed
+      MaxValue: 10
+      BaseValue: 0
+      CurValue: 0
+    Speed:
+      AttributeName: Speed
+      MaxValue: 10
+      BaseValue: 0
+      CurValue: 0
   calcVelocity: {x: 0, y: 0, z: 0}
   characterController: {fileID: 764802606740835985}
   jumpHeight: 2
@@ -64,17 +79,21 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 8
   groundCheckDistance: 0.3
+  isDead: 0
   animator: {fileID: 8904112648037604784}
   controller: {fileID: 2758657109547335978}
   fxSystem: {fileID: -8783207560054830842}
   abilitySystem: {fileID: 758250089743701821}
+  currentWeaponEffect: {fileID: 0}
   chaseRange: 5
   attackRange: 1.5
-  isDead: 0
   MaxBullet: 3
   patrolTime: 2
   startNode: {fileID: 0}
   roomGrid: {fileID: 0}
+  level: 0
+  aggro: 0
+  onlyIdle: 0
 --- !u!114 &6940413212348406184
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -214,13 +233,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2a5d62fbc178a804a9577f4b24d97ea7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  owner: {fileID: 0}
-  AbilityTag: 15
   AbilityName: 
+  AbilityTag: 15
   Duration: 0
   targetMask:
     serializedVersion: 2
     m_Bits: 128
+  owner: {fileID: 0}
+  fireCount: 1
+  fireMultypleAngleRange: 20
+  fireMultypleCount: 1
   eWeaponType: 0
   Equip_state_Tag: 21
 --- !u!1 &5838591459782860879
@@ -265,7 +287,7 @@ PrefabInstance:
     - target: {fileID: 1217557810167343886, guid: 446f9ff17434e8749a54822318712f49, type: 3}
       propertyPath: character
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 355589838402576648}
     - target: {fileID: 1217557810167343886, guid: 446f9ff17434e8749a54822318712f49, type: 3}
       propertyPath: m_bodys.Array.size
       value: 1

--- a/Assets/Prefabs/Monster/Burner.prefab
+++ b/Assets/Prefabs/Monster/Burner.prefab
@@ -51,11 +51,26 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   attribute:
-    MaxHart: 5
-    CurHart: 5
-    atk: 1
-    attackSpeed: 1
-    speed: 1
+    Health:
+      AttributeName: Health
+      MaxValue: 10
+      BaseValue: 0
+      CurValue: 0
+    Attack:
+      AttributeName: Attack
+      MaxValue: 10
+      BaseValue: 0
+      CurValue: 0
+    AttackSpeed:
+      AttributeName: AttackSpeed
+      MaxValue: 10
+      BaseValue: 0
+      CurValue: 0
+    Speed:
+      AttributeName: Speed
+      MaxValue: 10
+      BaseValue: 0
+      CurValue: 0
   calcVelocity: {x: 0, y: 0, z: 0}
   characterController: {fileID: 7238699780026430288}
   jumpHeight: 2
@@ -64,17 +79,21 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 8
   groundCheckDistance: 0.3
+  isDead: 0
   animator: {fileID: 1064726689573047387}
   controller: {fileID: 5989734767020855489}
   fxSystem: {fileID: -770563901117985350}
   abilitySystem: {fileID: 7643396454371422051}
+  currentWeaponEffect: {fileID: 0}
   chaseRange: 10
   attackRange: 3
-  isDead: 0
   MaxBullet: 3
   patrolTime: 2
   startNode: {fileID: 0}
   roomGrid: {fileID: 0}
+  level: 0
+  aggro: 0
+  onlyIdle: 0
 --- !u!114 &2563671461830074345
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -212,7 +231,7 @@ PrefabInstance:
     - target: {fileID: 1217557810167343886, guid: 446f9ff17434e8749a54822318712f49, type: 3}
       propertyPath: character
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 5582010176628933906}
     - target: {fileID: 1217557810167343886, guid: 446f9ff17434e8749a54822318712f49, type: 3}
       propertyPath: m_bodys.Array.size
       value: 1

--- a/Assets/Prefabs/Monster/Ninja.prefab
+++ b/Assets/Prefabs/Monster/Ninja.prefab
@@ -127,11 +127,26 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   attribute:
-    MaxHart: 5
-    CurHart: 5
-    atk: 1
-    attackSpeed: 1
-    speed: 1
+    Health:
+      AttributeName: Health
+      MaxValue: 10
+      BaseValue: 0
+      CurValue: 0
+    Attack:
+      AttributeName: Attack
+      MaxValue: 10
+      BaseValue: 0
+      CurValue: 0
+    AttackSpeed:
+      AttributeName: AttackSpeed
+      MaxValue: 10
+      BaseValue: 0
+      CurValue: 0
+    Speed:
+      AttributeName: Speed
+      MaxValue: 10
+      BaseValue: 0
+      CurValue: 0
   calcVelocity: {x: 0, y: 0, z: 0}
   characterController: {fileID: 4793144639647665465}
   jumpHeight: 2
@@ -140,17 +155,21 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 8
   groundCheckDistance: 0.3
+  isDead: 0
   animator: {fileID: 5467925109308273892}
   controller: {fileID: 1601174441402230910}
   fxSystem: {fileID: 5696247204516319646}
   abilitySystem: {fileID: 5314433099697966927}
+  currentWeaponEffect: {fileID: 0}
   chaseRange: 10
   attackRange: 9
-  isDead: 0
   MaxBullet: 3
   patrolTime: 2
   startNode: {fileID: 0}
   roomGrid: {fileID: 0}
+  level: 0
+  aggro: 0
+  onlyIdle: 0
   evadeRatio: 0.3
   armTrans: {fileID: 5467925110715598809}
 --- !u!114 &7836095756557533361
@@ -214,7 +233,7 @@ PrefabInstance:
     - target: {fileID: 1217557810167343886, guid: 446f9ff17434e8749a54822318712f49, type: 3}
       propertyPath: character
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 4253737156996786081}
     - target: {fileID: 1217557810167343886, guid: 446f9ff17434e8749a54822318712f49, type: 3}
       propertyPath: m_bodys.Array.size
       value: 1

--- a/Assets/Prefabs/Monster/Samurai.prefab
+++ b/Assets/Prefabs/Monster/Samurai.prefab
@@ -51,11 +51,26 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   attribute:
-    MaxHart: 5
-    CurHart: 5
-    atk: 1
-    attackSpeed: 1
-    speed: 1
+    Health:
+      AttributeName: Health
+      MaxValue: 10
+      BaseValue: 0
+      CurValue: 0
+    Attack:
+      AttributeName: Attack
+      MaxValue: 10
+      BaseValue: 0
+      CurValue: 0
+    AttackSpeed:
+      AttributeName: AttackSpeed
+      MaxValue: 10
+      BaseValue: 0
+      CurValue: 0
+    Speed:
+      AttributeName: Speed
+      MaxValue: 10
+      BaseValue: 0
+      CurValue: 0
   calcVelocity: {x: 0, y: 0, z: 0}
   characterController: {fileID: 764802606740835985}
   jumpHeight: 2
@@ -64,17 +79,21 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 8
   groundCheckDistance: 0.3
+  isDead: 0
   animator: {fileID: 8904112648037604784}
   controller: {fileID: 2758657109547335978}
   fxSystem: {fileID: -1166536410073215683}
   abilitySystem: {fileID: 8359127840597823985}
+  currentWeaponEffect: {fileID: 0}
   chaseRange: 5
   attackRange: 2
-  isDead: 0
   MaxBullet: 3
   patrolTime: 2
   startNode: {fileID: 0}
   roomGrid: {fileID: 0}
+  level: 0
+  aggro: 0
+  onlyIdle: 0
   evadeRatio: 0.3
 --- !u!114 &6940413212348406184
 MonoBehaviour:
@@ -275,7 +294,7 @@ PrefabInstance:
     - target: {fileID: 1217557810167343886, guid: 446f9ff17434e8749a54822318712f49, type: 3}
       propertyPath: character
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 5370123446938557922}
     - target: {fileID: 1217557810167343886, guid: 446f9ff17434e8749a54822318712f49, type: 3}
       propertyPath: m_bodys.Array.size
       value: 1

--- a/Assets/Prefabs/Monster/Soldier.prefab
+++ b/Assets/Prefabs/Monster/Soldier.prefab
@@ -51,11 +51,26 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   attribute:
-    MaxHart: 5
-    CurHart: 5
-    atk: 1
-    attackSpeed: 1
-    speed: 1
+    Health:
+      AttributeName: Health
+      MaxValue: 10
+      BaseValue: 0
+      CurValue: 0
+    Attack:
+      AttributeName: Attack
+      MaxValue: 10
+      BaseValue: 0
+      CurValue: 0
+    AttackSpeed:
+      AttributeName: AttackSpeed
+      MaxValue: 10
+      BaseValue: 0
+      CurValue: 0
+    Speed:
+      AttributeName: Speed
+      MaxValue: 10
+      BaseValue: 0
+      CurValue: 0
   calcVelocity: {x: 0, y: 0, z: 0}
   characterController: {fileID: 764802606740835985}
   jumpHeight: 2
@@ -64,17 +79,21 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 8
   groundCheckDistance: 0.3
+  isDead: 0
   animator: {fileID: 8904112648037604784}
-  controller: {fileID: 2758657109547335978}
+  controller: {fileID: 0}
   fxSystem: {fileID: 7337048175519719326}
   abilitySystem: {fileID: 2043262270310123978}
+  currentWeaponEffect: {fileID: 0}
   chaseRange: 7
   attackRange: 5
-  isDead: 0
   MaxBullet: 3
   patrolTime: 2
   startNode: {fileID: 0}
   roomGrid: {fileID: 0}
+  level: 0
+  aggro: 0
+  onlyIdle: 0
   BulletPrefab: {fileID: 0}
   gunTrans: {fileID: 1555058468039031767}
 --- !u!114 &6940413212348406184
@@ -214,7 +233,7 @@ PrefabInstance:
     - target: {fileID: 1217557810167343886, guid: 446f9ff17434e8749a54822318712f49, type: 3}
       propertyPath: character
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: -6665059317169354917}
     - target: {fileID: 1217557810167343886, guid: 446f9ff17434e8749a54822318712f49, type: 3}
       propertyPath: m_bodys.Array.size
       value: 1
@@ -375,6 +394,14 @@ PrefabInstance:
       propertyPath: 'm_heads.Array.data[18]'
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 1217557810167343886, guid: 446f9ff17434e8749a54822318712f49, type: 3}
+      propertyPath: 'm_weapons.Array.data[0]'
+      value: 
+      objectReference: {fileID: 4848333196644607021}
+    - target: {fileID: 1217557810167343886, guid: 446f9ff17434e8749a54822318712f49, type: 3}
+      propertyPath: 'm_weapons.Array.data[1]'
+      value: 
+      objectReference: {fileID: 8456174879193521918}
     - target: {fileID: 2538261173460028883, guid: 446f9ff17434e8749a54822318712f49, type: 3}
       propertyPath: m_IsActive
       value: 1
@@ -571,15 +598,26 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 2538261173460521459, guid: 446f9ff17434e8749a54822318712f49, type: 3}
   m_PrefabInstance: {fileID: 3939834277883685412}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &2758657109547335978 stripped
+--- !u!114 &4848333196644607021 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 1217557810167343886, guid: 446f9ff17434e8749a54822318712f49, type: 3}
+  m_CorrespondingSourceObject: {fileID: 8495380148740574729, guid: 446f9ff17434e8749a54822318712f49, type: 3}
   m_PrefabInstance: {fileID: 3939834277883685412}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 93005e4cac64995478b011a4506c7e69, type: 3}
+  m_Script: {fileID: 11500000, guid: 18698fe9baef4b0488e5c4ab914a10aa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &8456174879193521918 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4897458269767038170, guid: 446f9ff17434e8749a54822318712f49, type: 3}
+  m_PrefabInstance: {fileID: 3939834277883685412}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 18698fe9baef4b0488e5c4ab914a10aa, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!4 &8904112648037604783 stripped

--- a/Assets/Prefabs/Room/Room.prefab
+++ b/Assets/Prefabs/Room/Room.prefab
@@ -121,7 +121,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &217673400607916777
 GameObject:
@@ -244,7 +243,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &228389348144122801
 GameObject:
@@ -367,7 +365,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &340813024325312424
 GameObject:
@@ -490,7 +487,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &435900573176719283
 GameObject:
@@ -673,7 +669,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &744534814555370354
 GameObject:
@@ -796,7 +791,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &857592626002965541
 GameObject:
@@ -919,7 +913,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &1180632676585339069
 GameObject:
@@ -1042,7 +1035,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &1289819396142379899
 GameObject:
@@ -1165,7 +1157,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &1671634176216183780
 GameObject:
@@ -1288,7 +1279,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &1736673348154403910
 GameObject:
@@ -1411,7 +1401,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &2364256448960903750
 GameObject:
@@ -1579,7 +1568,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &2721326098213752475
 GameObject:
@@ -1702,7 +1690,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &2860738487088406540
 GameObject:
@@ -1825,7 +1812,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &2866484503392638134
 GameObject:
@@ -1948,7 +1934,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &2881319282393809819
 GameObject:
@@ -2224,7 +2209,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &3017635290553083298
 GameObject:
@@ -2392,7 +2376,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &3087242384911781569
 GameObject:
@@ -2515,7 +2498,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &3457394729465041267
 GameObject:
@@ -2638,7 +2620,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &3478932596216151407
 GameObject:
@@ -2761,7 +2742,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &3502607465236266801
 GameObject:
@@ -2993,7 +2973,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &3693321086423711881
 GameObject:
@@ -3116,7 +3095,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &3765995377457714779
 GameObject:
@@ -3239,7 +3217,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &3782729366466305443
 GameObject:
@@ -3407,7 +3384,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &4175420802522901717
 GameObject:
@@ -3530,7 +3506,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &4520912926051270850
 GameObject:
@@ -3713,7 +3688,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &5284004115940258478
 GameObject:
@@ -3836,7 +3810,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &5328299702198986204
 GameObject:
@@ -3915,8 +3888,8 @@ MonoBehaviour:
   toNextRoom: {fileID: 0}
   fromNodeGUID: 
   toNodeGUID: 
-  toNextSpawnPoint: {fileID: 2358385764457135105}
-  SpawnPoint: {fileID: 0}
+  toNextSpawnPoint: {fileID: 0}
+  SpawnPoint: {fileID: 2358385764457135105}
   traversal: {fileID: 3607143640234023030}
 --- !u!114 &7695628710433795156
 MonoBehaviour:
@@ -4052,7 +4025,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &5741594592311628799
 GameObject:
@@ -4130,8 +4102,8 @@ MonoBehaviour:
   toNextRoom: {fileID: 0}
   fromNodeGUID: 
   toNodeGUID: 
-  toNextSpawnPoint: {fileID: 7930996994651618566}
-  SpawnPoint: {fileID: 0}
+  toNextSpawnPoint: {fileID: 0}
+  SpawnPoint: {fileID: 7930996994651618566}
   traversal: {fileID: 7477970471993098497}
 --- !u!1 &5772689808066003875
 GameObject:
@@ -4254,7 +4226,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &5903822308785537917
 GameObject:
@@ -4377,7 +4348,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &5986841728024033953
 GameObject:
@@ -4500,7 +4470,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &6195089372332099775
 GameObject:
@@ -4702,7 +4671,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &6591503310716412824
 GameObject:
@@ -4930,7 +4898,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &6989986533745777966
 GameObject:
@@ -5148,7 +5115,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &7929196311616171822
 GameObject:
@@ -5271,7 +5237,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &8107644678793880209
 GameObject:
@@ -5454,7 +5419,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &8315226192999219454
 GameObject:
@@ -5577,7 +5541,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &8356782459759718623
 GameObject:
@@ -5901,7 +5864,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &8485487545970677349
 GameObject:
@@ -6024,7 +5986,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &8494454234967096951
 GameObject:
@@ -6147,7 +6108,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &8587252935273254241
 GameObject:
@@ -6270,7 +6230,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &8817966422006012284
 GameObject:
@@ -6393,7 +6352,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &8854459783580210797
 GameObject:
@@ -6516,7 +6474,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &8861468299529318220
 GameObject:
@@ -6639,7 +6596,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &8899682496263564638
 GameObject:
@@ -6822,7 +6778,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &8967817938545949781
 GameObject:
@@ -6945,7 +6900,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &8986806623550612517
 GameObject:
@@ -7068,7 +7022,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &9119443473795960095
 GameObject:
@@ -7191,7 +7144,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1 &9147998149475261793
 GameObject:
@@ -7314,7 +7266,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a3130873be12c9f4ea24b42062608aef, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wall: {fileID: 5935278547815300987, guid: e05ae677c7b3bc546bd36b488586fb0c, type: 3}
   exist: 0
 --- !u!1001 &279637007460592599
 PrefabInstance:

--- a/Assets/Scenes/BattleTest.unity
+++ b/Assets/Scenes/BattleTest.unity
@@ -13621,6 +13621,9 @@ MonoBehaviour:
   HandLeftAnim: {fileID: 2101642796}
   LowerarmLeftAnim: {fileID: 1730535414}
   LowerarmRightAnim: {fileID: 1490365126}
+  posxxx:
+    transform: {fileID: 0}
+    weight: 0
 --- !u!1001 &4659452295779773584
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -119,6 +119,11 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &9945442 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7101722475187744977, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &26910622
 GameObject:
   m_ObjectHideFlags: 0
@@ -240,6 +245,11 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 26910622}
   m_CullTransparentMesh: 1
+--- !u!1 &30260320 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3027464646441711849, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &88406296
 GameObject:
   m_ObjectHideFlags: 0
@@ -376,6 +386,17 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 88406296}
   m_CullTransparentMesh: 1
+--- !u!114 &128533251 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8197751098420373358, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 18698fe9baef4b0488e5c4ab914a10aa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &144422247
 GameObject:
   m_ObjectHideFlags: 0
@@ -689,6 +710,16 @@ MonoBehaviour:
   m_PointerBehavior: 0
   m_CursorLockBehavior: 0
   m_ScrollDeltaPerTick: 6
+--- !u!1 &247038371 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5907773872414427208, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &277196859 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1372882942246494168, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &342524338
 GameObject:
   m_ObjectHideFlags: 0
@@ -794,6 +825,11 @@ MonoBehaviour:
   fillDuration: 2
   slider: {fileID: 342524340}
   bossMonster: {fileID: 0}
+--- !u!1 &350732452 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4015941952045471057, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &366122899
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -907,6 +943,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1c5e0d87cf1d906479f35c069fcfba2f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &372305207 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2163547915057320771, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &410087039
 GameObject:
   m_ObjectHideFlags: 0
@@ -1103,6 +1144,17 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 442104284}
   m_CullTransparentMesh: 1
+--- !u!114 &474074379 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 9156603284253232412, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 750889185}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ce9b6abc9f37ae4e8741f8034296c8c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &479406659
 GameObject:
   m_ObjectHideFlags: 0
@@ -1231,10 +1283,10 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
---- !u!4 &492801827 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 2157046097784970231, guid: 4435ca00a4b7ed94ba6a732efa843ae2, type: 3}
-  m_PrefabInstance: {fileID: 1680803348}
+--- !u!1 &502755646 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 115406460377357693, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &575611706
 PrefabInstance:
@@ -1434,6 +1486,11 @@ Transform:
   - {fileID: 741164689}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &627865875 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4274362000619634153, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &650332802 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 9204853132282580513, guid: a860dd8f27743ad42ba4b8591da41450, type: 3}
@@ -1565,6 +1622,21 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1c5e0d87cf1d906479f35c069fcfba2f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &658164098 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4251482128501524258, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &661076408 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8771720668270239527, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &724783402 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6601497071983997489, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &741164685
 GameObject:
   m_ObjectHideFlags: 0
@@ -1786,6 +1858,106 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1c5e0d87cf1d906479f35c069fcfba2f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &750889184
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3499370228710893674, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+      propertyPath: m_Name
+      value: Player
+      objectReference: {fileID: 0}
+    - target: {fileID: 6033035017459168276, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6033035017459168276, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 5.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 6033035017459168276, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6033035017459168276, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6033035017459168276, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6033035017459168276, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6033035017459168276, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6033035017459168276, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6033035017459168276, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6033035017459168276, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9156603284253232412, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+      propertyPath: controller
+      value: 
+      objectReference: {fileID: 1972396733}
+    - target: {fileID: 9156603284253232412, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+      propertyPath: cameraTransform
+      value: 
+      objectReference: {fileID: 2878634503472795951}
+    - target: {fileID: 9156603284253232412, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+      propertyPath: inputController
+      value: 
+      objectReference: {fileID: 592921302}
+    - target: {fileID: 9156603284253232412, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+      propertyPath: itemdescriptionView
+      value: 
+      objectReference: {fileID: 1695879910}
+    m_RemovedComponents:
+    - {fileID: 3483381238265968467, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3499370228710893674, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 750889186}
+    - targetCorrespondingSourceObject: {fileID: 5355718062219726664, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+      insertIndex: 3
+      addedObject: {fileID: 1972396733}
+  m_SourcePrefab: {fileID: 100100000, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+--- !u!1 &750889185 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3499370228710893674, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &750889186
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 750889185}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9eff0bee02a52d345acaafff51e2899f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  tagSystem:
+    objectName: 
+  onTest: 1
 --- !u!1 &753566030
 GameObject:
   m_ObjectHideFlags: 0
@@ -1951,7 +2123,7 @@ MonoBehaviour:
   m_StreamingVersion: 20241001
   m_LegacyPriority: 0
   Target:
-    TrackingTarget: {fileID: 1108254531}
+    TrackingTarget: {fileID: 1655549905}
     LookAtTarget: {fileID: 0}
     CustomLookAtTarget: 0
   Lens:
@@ -1982,8 +2154,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 760378390}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.2448472, y: -0.000000011262764, z: 0.000000002844229, w: 0.9695617}
-  m_LocalPosition: {x: 0.00000005377585, y: 10.028696, z: -5.8346624}
+  m_LocalRotation: {x: 0.24485509, y: -0.0000000020898985, z: 5.2778854e-10, w: 0.9695597}
+  m_LocalPosition: {x: 0.000000009978485, y: 10.028733, z: -5.8346424}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -2283,6 +2455,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   localizationID: Condtion_Score
+--- !u!1 &787189035 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4135263100120177198, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &813157865
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2396,6 +2573,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1c5e0d87cf1d906479f35c069fcfba2f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &822705487 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5053299420551502413, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &832575517
 GameObject:
   m_ObjectHideFlags: 0
@@ -2445,6 +2627,37 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &841592468 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 9212426443394209201, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &878535300 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7842855438559658318, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &913215787 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1223214939894188389, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &926243507 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7065899589908656897, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &938979953 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5350770602380368759, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 18698fe9baef4b0488e5c4ab914a10aa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &951857875
 GameObject:
   m_ObjectHideFlags: 0
@@ -2868,55 +3081,47 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 7008538225500624665, guid: b42006b2375875f4388c4bef534d9547, type: 3}
   m_PrefabInstance: {fileID: 1022431421}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1025489988
+--- !u!1 &1072686638 stripped
 GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 3445716968856947158, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
   m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1025489990}
-  - component: {fileID: 1025489989}
-  m_Layer: 0
-  m_Name: TagDebugger
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1025489989
+--- !u!1 &1083102261 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4906058026721346797, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1090215297 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2191322474398196031, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1100058877 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3337440325306026196, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1213975898 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1410392239603405079, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1215360472 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1580391421228595334, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1222806101 stripped
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 4657690215199160261, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1025489988}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9eff0bee02a52d345acaafff51e2899f, type: 3}
+  m_Script: {fileID: 11500000, guid: 18698fe9baef4b0488e5c4ab914a10aa, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &1025489990
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1025489988}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &1108254531 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 6387495218651356608, guid: 4435ca00a4b7ed94ba6a732efa843ae2, type: 3}
-  m_PrefabInstance: {fileID: 1680803348}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1236261274 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 3909434617314791119, guid: a860dd8f27743ad42ba4b8591da41450, type: 3}
@@ -2935,51 +3140,21 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   localizationID: Condition_Speed
---- !u!1 &1249042184
+--- !u!1 &1254054687 stripped
 GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 8428438694291164626, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
   m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1249042185}
-  - component: {fileID: 1249042186}
-  m_Layer: 7
-  m_Name: GameObject
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1249042185
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+--- !u!1 &1254603253 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 9180235951046387266, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1249042184}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1640320757}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1249042186
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+--- !u!1 &1291284908 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 990277058234112089, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1249042184}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 82086ece39dc9774b9b2dda665b01ee7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  bodyTrans: {fileID: 492801827}
 --- !u!1001 &1345133732
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3028,6 +3203,22 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8005795573586393356, guid: 0b85980c3f962c748be49d151a89fccf, type: 3}
+      propertyPath: projectilePrefabs.Array.size
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 8005795573586393356, guid: 0b85980c3f962c748be49d151a89fccf, type: 3}
+      propertyPath: 'projectilePrefabs.Array.data[0]'
+      value: 
+      objectReference: {fileID: -129116346194053633, guid: bfcb8e91e8801de4a89f81af91e67eb0, type: 3}
+    - target: {fileID: 8005795573586393356, guid: 0b85980c3f962c748be49d151a89fccf, type: 3}
+      propertyPath: 'projectilePrefabs.Array.data[1]'
+      value: 
+      objectReference: {fileID: 429075340263493928, guid: 91d744c21a07d864ebe624dabfdf4dce, type: 3}
+    - target: {fileID: 8005795573586393356, guid: 0b85980c3f962c748be49d151a89fccf, type: 3}
+      propertyPath: 'projectilePrefabs.Array.data[3]'
+      value: 
+      objectReference: {fileID: 8330350943485095958, guid: 6dcbaadfc2e19724292dcc7c68107d9a, type: 3}
     - target: {fileID: 9102344022872372180, guid: 0b85980c3f962c748be49d151a89fccf, type: 3}
       propertyPath: m_Name
       value: Factory
@@ -3037,6 +3228,16 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0b85980c3f962c748be49d151a89fccf, type: 3}
+--- !u!1 &1363794796 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5620731407719774132, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1380195768 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5076840329801328447, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1388954899 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 8362387743292551223, guid: a860dd8f27743ad42ba4b8591da41450, type: 3}
@@ -3207,6 +3408,21 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   localizationID: Condtion_ReStart
+--- !u!1 &1413927627 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3638041912570561979, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1439341211 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4944814007702728075, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1458944010 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 798549006262798705, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1500490922
 GameObject:
   m_ObjectHideFlags: 0
@@ -3449,6 +3665,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 063d13319c25da240a3772cd8a6d02cb, type: 3}
+--- !u!1 &1584081421 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2999059805045504880, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1626663309
 GameObject:
   m_ObjectHideFlags: 0
@@ -3559,150 +3780,26 @@ MonoBehaviour:
   m_Spacing: {x: 2, y: 2}
   m_Constraint: 0
   m_ConstraintCount: 2
---- !u!114 &1640320756 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6462978079765270456, guid: 4435ca00a4b7ed94ba6a732efa843ae2, type: 3}
-  m_PrefabInstance: {fileID: 1680803348}
+--- !u!1 &1653850956 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3214068859459886628, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9ce9b6abc9f37ae4e8741f8034296c8c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!4 &1640320757 stripped
+--- !u!4 &1655549905 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 3699101498662529524, guid: 4435ca00a4b7ed94ba6a732efa843ae2, type: 3}
-  m_PrefabInstance: {fileID: 1680803348}
+  m_CorrespondingSourceObject: {fileID: 4752143921221765227, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &1680803348
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 1805356684446764008, guid: 4435ca00a4b7ed94ba6a732efa843ae2, type: 3}
-      propertyPath: m_Name
-      value: Player
-      objectReference: {fileID: 0}
-    - target: {fileID: 3699101498662529524, guid: 4435ca00a4b7ed94ba6a732efa843ae2, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3699101498662529524, guid: 4435ca00a4b7ed94ba6a732efa843ae2, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 5.27
-      objectReference: {fileID: 0}
-    - target: {fileID: 3699101498662529524, guid: 4435ca00a4b7ed94ba6a732efa843ae2, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3699101498662529524, guid: 4435ca00a4b7ed94ba6a732efa843ae2, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3699101498662529524, guid: 4435ca00a4b7ed94ba6a732efa843ae2, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3699101498662529524, guid: 4435ca00a4b7ed94ba6a732efa843ae2, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3699101498662529524, guid: 4435ca00a4b7ed94ba6a732efa843ae2, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3699101498662529524, guid: 4435ca00a4b7ed94ba6a732efa843ae2, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3699101498662529524, guid: 4435ca00a4b7ed94ba6a732efa843ae2, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3699101498662529524, guid: 4435ca00a4b7ed94ba6a732efa843ae2, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3819367472279800127, guid: 4435ca00a4b7ed94ba6a732efa843ae2, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 2.72
-      objectReference: {fileID: 0}
-    - target: {fileID: 3819367472279800127, guid: 4435ca00a4b7ed94ba6a732efa843ae2, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -2.63
-      objectReference: {fileID: 0}
-    - target: {fileID: 3819367472279800127, guid: 4435ca00a4b7ed94ba6a732efa843ae2, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.792169
-      objectReference: {fileID: 0}
-    - target: {fileID: 3819367472279800127, guid: 4435ca00a4b7ed94ba6a732efa843ae2, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.46906808
-      objectReference: {fileID: 0}
-    - target: {fileID: 3819367472279800127, guid: 4435ca00a4b7ed94ba6a732efa843ae2, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.3359602
-      objectReference: {fileID: 0}
-    - target: {fileID: 3819367472279800127, guid: 4435ca00a4b7ed94ba6a732efa843ae2, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.19893263
-      objectReference: {fileID: 0}
-    - target: {fileID: 5427188757696776923, guid: 4435ca00a4b7ed94ba6a732efa843ae2, type: 3}
-      propertyPath: m_Name
-      value: lockOnCam Group
-      objectReference: {fileID: 0}
-    - target: {fileID: 5825741382810516601, guid: 4435ca00a4b7ed94ba6a732efa843ae2, type: 3}
-      propertyPath: Targets.Array.size
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5825741382810516601, guid: 4435ca00a4b7ed94ba6a732efa843ae2, type: 3}
-      propertyPath: Targets.Array.data[0].Object
-      value: 
-      objectReference: {fileID: 1108254531}
-    - target: {fileID: 5825741382810516601, guid: 4435ca00a4b7ed94ba6a732efa843ae2, type: 3}
-      propertyPath: Targets.Array.data[0].Radius
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5825741382810516601, guid: 4435ca00a4b7ed94ba6a732efa843ae2, type: 3}
-      propertyPath: Targets.Array.data[0].Weight
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6462978079765270456, guid: 4435ca00a4b7ed94ba6a732efa843ae2, type: 3}
-      propertyPath: fxSystem
-      value: 
-      objectReference: {fileID: 1249042186}
-    - target: {fileID: 6462978079765270456, guid: 4435ca00a4b7ed94ba6a732efa843ae2, type: 3}
-      propertyPath: cameraTransform
-      value: 
-      objectReference: {fileID: 3545643549069682311}
-    - target: {fileID: 6462978079765270456, guid: 4435ca00a4b7ed94ba6a732efa843ae2, type: 3}
-      propertyPath: inputController
-      value: 
-      objectReference: {fileID: 592921302}
-    - target: {fileID: 6462978079765270456, guid: 4435ca00a4b7ed94ba6a732efa843ae2, type: 3}
-      propertyPath: itemdescriptionView
-      value: 
-      objectReference: {fileID: 1695879910}
-    - target: {fileID: 6849201056815116209, guid: 4435ca00a4b7ed94ba6a732efa843ae2, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -5.27
-      objectReference: {fileID: 0}
-    - target: {fileID: 7011079490586622914, guid: 4435ca00a4b7ed94ba6a732efa843ae2, type: 3}
-      propertyPath: Priority.m_Value
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 3699101498662529524, guid: 4435ca00a4b7ed94ba6a732efa843ae2, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1249042185}
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 4435ca00a4b7ed94ba6a732efa843ae2, type: 3}
+--- !u!1 &1666342291 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6801559266755125259, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1684174777 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 311006057720701336, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1687979419
 GameObject:
   m_ObjectHideFlags: 0
@@ -4337,6 +4434,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   img: {fileID: 1756707808}
+--- !u!1 &1848118121 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7746046085241839692, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1864336793
 GameObject:
   m_ObjectHideFlags: 0
@@ -4487,6 +4589,85 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1864336793}
   m_CullTransparentMesh: 1
+--- !u!1 &1916266602 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6305595760806620517, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1956992120 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8538575014073479405, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1972396727 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5355718062219726664, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1972396733
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1972396727}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 90808514f8898504998f87cb37477b25, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_heads:
+  - {fileID: 1413927627}
+  - {fileID: 372305207}
+  - {fileID: 9945442}
+  - {fileID: 2095248401}
+  - {fileID: 247038371}
+  - {fileID: 1213975898}
+  - {fileID: 1653850956}
+  - {fileID: 1380195768}
+  - {fileID: 627865875}
+  - {fileID: 350732452}
+  - {fileID: 1254054687}
+  - {fileID: 1684174777}
+  - {fileID: 724783402}
+  - {fileID: 1956992120}
+  - {fileID: 1848118121}
+  - {fileID: 1215360472}
+  - {fileID: 878535300}
+  - {fileID: 1090215297}
+  - {fileID: 502755646}
+  - {fileID: 661076408}
+  m_bodys:
+  - {fileID: 926243507}
+  - {fileID: 2054040443}
+  - {fileID: 1291284908}
+  - {fileID: 913215787}
+  - {fileID: 1100058877}
+  - {fileID: 1083102261}
+  - {fileID: 822705487}
+  - {fileID: 1254603253}
+  - {fileID: 1439341211}
+  - {fileID: 658164098}
+  - {fileID: 1458944010}
+  - {fileID: 1363794796}
+  - {fileID: 787189035}
+  - {fileID: 1666342291}
+  - {fileID: 1584081421}
+  - {fileID: 841592468}
+  - {fileID: 1916266602}
+  - {fileID: 277196859}
+  - {fileID: 30260320}
+  - {fileID: 1072686638}
+  m_weapons:
+  - {fileID: 938979953}
+  - {fileID: 1222806101}
+  - {fileID: 128533251}
+  character: {fileID: 474074379}
+  HeadAnim: {fileID: 0}
+  HandRighAnim: {fileID: 0}
+  HandLeftAnim: {fileID: 0}
+  LowerarmLeftAnim: {fileID: 0}
+  LowerarmRightAnim: {fileID: 0}
 --- !u!1 &2011068932
 GameObject:
   m_ObjectHideFlags: 0
@@ -4531,12 +4712,17 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 364a70f1ac597584dbc19bba561ca975, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  player: {fileID: 1640320756}
+  player: {fileID: 474074379}
   dungeon: {fileID: 0}
   dungeonMaker: {fileID: 6084434126854662743}
   curRoom: {fileID: 0}
   gameOver: {fileID: 144422253}
   bossHud: {fileID: 342524341}
+--- !u!1 &2054040443 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8392297761289550467, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
 --- !u!224 &2075920016 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 6307898525145915734, guid: 23f64ecd0cfe8a442b08824aab3b1a29, type: 3}
@@ -4618,6 +4804,11 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2086902483}
   m_CullTransparentMesh: 1
+--- !u!1 &2095248401 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 9089997623993568654, guid: 9f8e21282b3b1884183c7faeaf0b8313, type: 3}
+  m_PrefabInstance: {fileID: 750889184}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &2121372783 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 5723505051276929739, guid: a860dd8f27743ad42ba4b8591da41450, type: 3}
@@ -4668,8 +4859,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7466947737233708685}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.24484721, y: -0.000000011262765, z: 0.0000000028442302, w: 0.9695617}
-  m_LocalPosition: {x: 0.000000053775842, y: 10.028696, z: -5.834662}
+  m_LocalRotation: {x: 0.2448551, y: -0.0000000020898985, z: 5.277883e-10, w: 0.96955967}
+  m_LocalPosition: {x: 0.000000009978482, y: 10.028734, z: -5.834642}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -5022,11 +5213,10 @@ SceneRoots:
   - {fileID: 832575519}
   - {fileID: 2011068934}
   - {fileID: 2878634503472795951}
-  - {fileID: 1680803348}
+  - {fileID: 750889184}
   - {fileID: 592921303}
   - {fileID: 209396731}
   - {fileID: 479406663}
-  - {fileID: 1025489990}
   - {fileID: 6084434126854662741}
   - {fileID: 760378394}
   - {fileID: 585294186}

--- a/Assets/Scenes/LobbyScene.unity
+++ b/Assets/Scenes/LobbyScene.unity
@@ -4925,7 +4925,7 @@ MonoBehaviour:
   - {fileID: 8300000, guid: 6884d38a5d16af94f81fe376c02d831f, type: 3}
   - {fileID: 8300000, guid: 950522cbc65e9b042bd7dc3637fa37b3, type: 3}
   - {fileID: 8300000, guid: 02f7b58b5114fc74eb71cc55573729a3, type: 3}
-  audioSource: {fileID: 0}
+  audioSource: {fileID: 9059782121223899282}
   gameeffectSound:
   - {fileID: 8300000, guid: e43075a998e485642ac17612d47ade2c, type: 3}
   - {fileID: 8300000, guid: 46d289cd9cedc5c42ba26b8bf798878f, type: 3}

--- a/Assets/Scripts/Character/Character.cs
+++ b/Assets/Scripts/Character/Character.cs
@@ -57,7 +57,7 @@ public class Character : AttributeEntity , ILockOnTarget , IGameAbilityCharacter
 
     public WeaponController currentWeaponEffect;
 
-    private void Awake()
+    protected virtual void Awake()
     {
         abilitySystem = GetComponentInChildren<AbilitySystem>();
         currentWeaponEffect = null;

--- a/Assets/Scripts/Character/ModelController.cs
+++ b/Assets/Scripts/Character/ModelController.cs
@@ -18,21 +18,14 @@ public class ModelController : MonoBehaviour
     public GameObject[] m_bodys;
    
     public WeaponController[] m_weapons;
-
     public Dictionary<eWeaponType, WeaponController> dicWeapons;
 
     public Character character;
 
-    public Rig HeadAnim;
-    public Rig HandRighAnim;
-    public Rig HandLeftAnim;
-    public Rig LowerarmLeftAnim;
-    public Rig LowerarmRightAnim;
-
 
     //파츠바디 타입에는 무기를 포함하지않는다.
     public Dictionary<eEuipmentType, List<GameObject>> partsByType = new Dictionary<eEuipmentType, List<GameObject>>();
-    private void InitializeParts()
+    protected virtual void InitializeParts()
     {
         // 배열을 Dictionary에 등록합니다.
         partsByType[eEuipmentType.Head] = new List<GameObject>(m_heads);
@@ -53,34 +46,8 @@ public class ModelController : MonoBehaviour
                 //Debug.LogWarning($"[{partType}] 파츠 목록이 비어있습니다.");
             }
         }
-        dicWeapons = new Dictionary<eWeaponType, WeaponController>();
-        foreach (var weapon in m_weapons)
-        {
-            dicWeapons.Add(weapon.eWeaponType, weapon);
-        }
-
-        ScanForTargets.OnSetLockOnTarget += OnSetLockOnTarget;
     }
 
-    public WeightedTransform posxxx;
-
-    public void OnSetLockOnTarget(Transform Target)
-    {
-
-    }
-
-    private void AimingPosesRigging(Rig weiponAimLayer, Transform Target)
-    {
-
-
-        weiponAimLayer.weight = 1;
-        GameObject child = weiponAimLayer.transform.GetChild(0).gameObject;
-        MultiAimConstraint childCompo =  child.GetComponent<MultiAimConstraint>();
-
-        childCompo.weight = 1;
-        posxxx = childCompo.data.sourceObjects[0];
-        
-    }
 
 
 
@@ -139,24 +106,25 @@ public class ModelController : MonoBehaviour
         }
     }
 
-    public void SetWeaponByIndex(eWeaponType type)
-    {      
-        foreach(var weapon in dicWeapons)
+
+
+    #endregion
+
+
+    public virtual void SetWeaponByIndex(eWeaponType type)
+    {
+        foreach (var weapon in dicWeapons)
         {
             bool isActive = type == weapon.Key;
             dicWeapons[weapon.Key].gameObject.SetActive(isActive);
 
             //활성화된 현제 무기
             if (isActive)
-            {                
+            {
                 character.SetWeaponEffect(dicWeapons[type]);
             }
         }
     }
-
-
-    #endregion
-
 
 
 }

--- a/Assets/Scripts/Character/RigModelController.cs
+++ b/Assets/Scripts/Character/RigModelController.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Animations.Rigging;
+
+
+public class RigModelController : ModelController
+{
+
+    public Rig HeadAnim;
+    public Rig HandRighAnim;
+    public Rig HandLeftAnim;
+    public Rig LowerarmLeftAnim;
+    public Rig LowerarmRightAnim;
+
+
+    //파츠바디 타입에는 무기를 포함하지않는public Dictionary<eEuipmentType, List<GameObject>> partsByType = new Dictionary<eEuipmentType, List<GameObject>>();다.    
+    protected override  void InitializeParts()
+    {
+        base.InitializeParts();     
+    }
+
+    public void OnSetLockOnTarget(Transform Target)
+    {
+
+    }
+
+    private void Awake()
+    {
+        InitializeParts();
+        dicWeapons = new Dictionary<eWeaponType, WeaponController>();
+        foreach (var weapon in m_weapons)
+        {
+            dicWeapons.Add(weapon.eWeaponType, weapon);
+        }
+    }
+
+
+
+
+
+}

--- a/Assets/Scripts/Character/RigModelController.cs.meta
+++ b/Assets/Scripts/Character/RigModelController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 90808514f8898504998f87cb37477b25

--- a/Assets/Scripts/Edit/DungeonGenerator.cs
+++ b/Assets/Scripts/Edit/DungeonGenerator.cs
@@ -249,9 +249,10 @@ public class DungeonGenerator : MonoBehaviour
 
     private void CreateStartRoomItem(Room room)
     {
-        int weaponIndex = Random.Range(0, 3);
+        //int weaponIndex = Random.Range(0, 3);
+        int rifleIndex = 0;
         var node = room.grid.GetFirstGridNode();
-        ResourceManager.Instance.CreateWeaponItemToIndex(weaponIndex, node.transform);
+        ResourceManager.Instance.CreateWeaponItemToIndex(rifleIndex, node.transform);
     }
 
     private Monster InstantiateMonster(Room room, MonsterDataSO data, string namePrefix, float scaleMultiplier = 1.0f)

--- a/Assets/Scripts/Edit/TagDebugger.cs
+++ b/Assets/Scripts/Edit/TagDebugger.cs
@@ -14,7 +14,7 @@ public class TagDebugger : MonoBehaviour
               
         if (tagSystem == null)
         {
-            tagSystem = GameManager.instance.GetPlayer().GetGameplayTagSystem();
+            tagSystem = GetComponent<Player>().GetGameplayTagSystem();
         }
 
         GUIStyle style = new GUIStyle(GUI.skin.label);

--- a/Assets/Scripts/Monster/Monster.cs
+++ b/Assets/Scripts/Monster/Monster.cs
@@ -221,8 +221,9 @@ public abstract class Monster : Character
 
         characterController.Move(calcVelocity * Time.deltaTime);
     }
-    protected void Awake()
+    protected override void Awake()
     {
+        base.Awake();
         onlyIdle = true;
     }
 

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -60,8 +60,9 @@ public partial class Player : Character , IOnGameOver ,IOnNextFlow , IController
 
     public readonly float portalDelay = GlobalDefine.PlayerPortalDelayTime;
 
-    private void Awake()
+    protected override void Awake()
     {
+        base.Awake();
         GameManager.OnGameOver += OnGameOver;
         GameManager.OnNextFlow += OnNextFlow;
         itemLayer = LayerMask.NameToLayer(GlobalDefine.String_Item);
@@ -107,7 +108,7 @@ public partial class Player : Character , IOnGameOver ,IOnNextFlow , IController
         ActivateAbilityAttack();
 
         FallDeathCheck();
-    }
+    } 
 
 
     private void ActivateAbilityAttack()
@@ -329,10 +330,8 @@ public partial class Player : Character , IOnGameOver ,IOnNextFlow , IController
 
     public void ResetTarget()
     {        
-        bool onTargetRemove  = scanForTargets.ResetTarget();
-        
-        if (onTargetRemove)
-            gameplayTagSystem.RemoveTag(eTagType.Player_State_HasAttackTarget);
+        scanForTargets.ResetTarget();        
+        gameplayTagSystem.RemoveTag(eTagType.Player_State_HasAttackTarget);
     }
 
     public void PlayAnimIdle()

--- a/Assets/Scripts/Player/ScanForTargets.cs
+++ b/Assets/Scripts/Player/ScanForTargets.cs
@@ -20,8 +20,15 @@ public class ScanForTargets : MonoBehaviour
         get
         {
             if (_lookatMonster == null || _lookatMonster.GetDead())
+            {
+                ResetTarget();
                 return null;
-            return _lookatMonster.GetLockOnTransform();
+            }
+            else
+            {
+                return _lookatMonster.GetLockOnTransform();
+            }                
+            
         }
     }
 
@@ -60,16 +67,14 @@ public class ScanForTargets : MonoBehaviour
         }
     }
 
-    public bool ResetTarget()
+    public void ResetTarget()
     {
         if(m_TargetGroup.Targets.Count > condition)
         {
             Transform targetToRemove = m_TargetGroup.Targets[TargetIndex].Object;
             m_TargetGroup.RemoveMember(targetToRemove);
             _lookatMonster = null;  
-            return true;
         }
-        return false;
     }
 }
 

--- a/Assets/Scripts/System/InputController.cs
+++ b/Assets/Scripts/System/InputController.cs
@@ -131,8 +131,6 @@ public class InputController : MonoBehaviour
 
     void RaycastToMonster(Vector2 screenPosition)
     {
-        if (alreadyhasTarget == true)
-            return;
 
         Ray ray = mainCamera.ScreenPointToRay(screenPosition);
 
@@ -145,10 +143,9 @@ public class InputController : MonoBehaviour
             if (lockOnTarget != null && lockOnTarget.GetDead() == false)
             {
                 controllerCharacter.SetPlayerTarget(lockOnTarget);                
-                alreadyhasTarget = true; 
                 return;
-            }
             
+            }
         }
         controllerCharacter.ResetTarget();
     }

--- a/Assets/Scripts/System/SoundManager.cs
+++ b/Assets/Scripts/System/SoundManager.cs
@@ -42,6 +42,8 @@ public class SoundManager : MonoBehaviour
         if (instance == null)
         {
             instance = this;
+            audioSource = GetComponent<AudioSource>();
+            Setup();
             DontDestroyOnLoad(gameObject);
         }
         else
@@ -50,12 +52,7 @@ public class SoundManager : MonoBehaviour
         }
     }
 
-    private void Start()
-    {
-        audioSource = GetComponent<AudioSource>();
-        
-        Setup();
-    }
+    
 
     private void Setup()
     {

--- a/Assets/WeaponController.cs
+++ b/Assets/WeaponController.cs
@@ -19,8 +19,18 @@ public class WeaponController : MonoBehaviour
 
     public void PlayEffect()
     {
-        SoundManager.instance.PlayEffect(eEffectType.Shoot, bulletStartPos);
-        muzzle.Play();
+        try
+        {
+            SoundManager.instance.PlayEffect(eEffectType.Shoot, bulletStartPos);
+        }
+        catch (System.Exception e)
+        {
+            Debug.LogException(e);
+        }
+        finally
+        {
+            muzzle.Play();
+        }            
     }
 
 


### PR DESCRIPTION
1. 모델 컨트롤러 자식 클래스 rig모델 컨트롤러 프레임 워크 분리
2. 웨폰 아이템 라이플만 생성되게끔 수정
3. 타겟서치 모듈 버그 수정 (로직과 맞지않는 예외처리 삭제)
4. 로비씬 생명주기 플로우 잘못됨 버그 해결
5. 플레이어 프리펩 수정